### PR TITLE
Add procps and nano back by default in the system distro.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -255,7 +255,9 @@ RUN tdnf    install -y \
             libXcursor \
             libxkbcommon \
             libXrandr \
+            nano \
             pango \
+            procps-ng \
             tzdata \
             UI-cairo \
             wayland-protocols-devel \
@@ -268,8 +270,6 @@ ARG SYSTEMDISTRO_DEBUG_BUILD
 RUN if [ "$SYSTEMDISTRO_DEBUG_BUILD" = "on" ] ; then \
         tdnf install -y \
              gdb \
-             nano \
-             procps-ng \
              vim ; \
     else                                            \
         rpm -e --nodeps python2                     \


### PR DESCRIPTION
Hardly take any space and super useful (see #126)