### PR TITLE
WSLDVCPlugin: Fix debug build typo.

### DIFF
--- a/WSLDVCPlugin/WSLDVCCallback.cpp
+++ b/WSLDVCPlugin/WSLDVCCallback.cpp
@@ -546,7 +546,7 @@ public:
             {
                 return hr;
             }
-            assert(m_spFileDBSync->Get());
+            assert(m_spFileDBSync.Get());
         }
 
         if (updateAppList.flags & (RDPAPPLIST_HINT_SYNC | RDPAPPLIST_HINT_SYNC_END))


### PR DESCRIPTION
Get() is a public method of Comptr class.