### PR TITLE
move rdpapplist to WSLg project from FreeRDP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ ENV BUILDTYPE=release
 ENV DESTDIR=/work/build
 ENV PREFIX=/usr
 ENV PKG_CONFIG_PATH=${DESTDIR}${PREFIX}/lib/pkgconfig:${DESTDIR}${PREFIX}/lib/${WSLG_ARCH}-linux-gnu/pkgconfig:${DESTDIR}${PREFIX}/share/pkgconfig
-ENV C_INCLUDE_PATH=${DESTDIR}${PREFIX}/include/freerdp2:${DESTDIR}${PREFIX}/include/winpr2
+ENV C_INCLUDE_PATH=${DESTDIR}${PREFIX}/include/freerdp2:${DESTDIR}${PREFIX}/include/winpr2:${DESTDIR}${PREFIX}/include
 ENV CPLUS_INCLUDE_PATH=${C_INCLUDE_PATH}
 ENV LIBRARY_PATH=${DESTDIR}${PREFIX}/lib
 ENV LD_LIBRARY_PATH=${LIBRARY_PATH}
@@ -165,6 +165,13 @@ RUN cmake -G Ninja \
         -DWITH_SAMPLE=OFF && \
     ninja -C build -j8 install
 RUN echo 'FreeRDP:' `git --git-dir=/work/vendor/FreeRDP/.git rev-parse --verify HEAD` >> /work/versions.txt
+
+# Build rdpapplist RDP virtual channel plugin
+COPY rdpapplist /work/rdpapplist
+WORKDIR /work/rdpapplist
+RUN /usr/bin/meson --prefix=${PREFIX} build \
+        --buildtype=${BUILDTYPE} && \
+    ninja -C build -j8 install
 
 # Build Weston
 COPY vendor/weston /work/vendor/weston

--- a/rdpapplist/meson.build
+++ b/rdpapplist/meson.build
@@ -1,0 +1,51 @@
+project('rdpapplist',
+    'c',
+    version : '1.0.0',
+)
+
+name_rdpapplist = meson.project_name()
+version_rdpapplist = meson.project_version()
+
+config_h = configuration_data()
+
+dir_prefix = get_option('prefix')
+
+dir_lib = join_paths(dir_prefix, get_option('libdir'))
+install_lib_dir_rdpapplist = join_paths(dir_lib, name_rdpapplist)
+config_h.set_quoted('RDPAPPLIST_MODULEDIR',
+     install_lib_dir_rdpapplist)
+
+dir_inc = join_paths(dir_prefix, get_option('includedir'))
+install_inc_dir_rdpapplist = join_paths(dir_inc, name_rdpapplist)
+config_h.set_quoted('RDPAPPLIST_INCLUDEDIR',
+     install_inc_dir_rdpapplist)
+
+dep_frdp = dependency('freerdp2', version: '>= 2.0.0', required: false)
+if not dep_frdp.found()
+    error('rdpapplist requires freerdp2 which was not found.')
+endif
+
+dep_winpr = dependency('winpr2', version: '>= 2.0.0', required: false)
+if not dep_winpr.found()
+    error('rdpapplist requires winpr2 which was not found.')
+endif
+
+configure_file(output: 'rdpapplist_config.h',
+     configuration: config_h,
+     install_dir: install_inc_dir_rdpapplist)
+
+subdir('server')
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+    filebase: name_rdpapplist,
+    version: version_rdpapplist,
+    name: 'Application list Plugin for FreeRDP',
+    description: 'Header files for Application list Plugin for FreeRDP',
+)
+
+install_headers(
+    'rdpapplist_protocol.h',
+    'rdpapplist_server.h',
+    subdir: name_rdpapplist,
+)

--- a/rdpapplist/rdpapplist_common.c
+++ b/rdpapplist/rdpapplist_common.c
@@ -1,0 +1,60 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RDPXXXX Remote Application List Virtual Channel Extension
+ *
+ * Copyright 2020 Microsoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <winpr/crt.h>
+#include <winpr/stream.h>
+#include <freerdp/channels/log.h>
+
+#define TAG CHANNELS_TAG("rdpapplist.common")
+
+#include "rdpapplist_common.h"
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+UINT rdpapplist_read_header(wStream* s, RDPAPPLIST_HEADER* header)
+{
+	if (Stream_GetRemainingLength(s) < 8)
+	{
+		WLog_ERR(TAG, "header parsing failed: not enough data!");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT32(s, header->cmdId);
+	Stream_Read_UINT32(s, header->length);
+	return CHANNEL_RC_OK;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+UINT rdpapplist_write_header(wStream* s, const RDPAPPLIST_HEADER* header)
+{
+	Stream_Write_UINT32(s, header->cmdId);
+	Stream_Write_UINT32(s, header->length);
+	return CHANNEL_RC_OK;
+}

--- a/rdpapplist/rdpapplist_common.h
+++ b/rdpapplist/rdpapplist_common.h
@@ -1,0 +1,32 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RDPXXXX Remote Application List Virtual Channel Extension
+ *
+ * Copyright 2020 Microsoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_RDPAPPLIST_COMMON_H
+#define FREERDP_CHANNEL_RDPAPPLIST_COMMON_H
+
+#include <winpr/crt.h>
+#include <winpr/stream.h>
+
+#include <freerdp/api.h>
+#include <rdpapplist_protocol.h>
+
+FREERDP_LOCAL UINT rdpapplist_read_header(wStream* s, RDPAPPLIST_HEADER* header);
+FREERDP_LOCAL UINT rdpapplist_write_header(wStream* s, const RDPAPPLIST_HEADER* header);
+
+#endif /* FREERDP_CHANNEL_RDPAPPLIST_COMMON_H */

--- a/rdpapplist/rdpapplist_protocol.h
+++ b/rdpapplist/rdpapplist_protocol.h
@@ -1,0 +1,143 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RDPXXXX Remote Application List Virtual Channel Extension
+ *
+ * Copyright 2020 Microsoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_RDPAPPLIST_H
+#define FREERDP_CHANNEL_RDPAPPLIST_H
+
+#include <freerdp/api.h>
+#include <freerdp/types.h>
+#include <freerdp/rail.h>
+
+#define RDPAPPLIST_DVC_CHANNEL_NAME "Microsoft::Windows::RDS::RemoteApplicationList"
+
+#define RDPAPPLIST_CHANNEL_VERSION 3
+
+#define RDPAPPLIST_CMDID_CAPS 0x00000001
+#define RDPAPPLIST_CMDID_UPDATE_APPLIST 0x00000002
+#define RDPAPPLIST_CMDID_DELETE_APPLIST 0x00000003
+#define RDPAPPLIST_CMDID_DELETE_APPLIST_PROVIDER 0x00000004
+
+#define RDPAPPLIST_ICON_FORMAT_PNG 0x0001
+#define RDPAPPLIST_ICON_FORMAT_BMP 0x0002
+#define RDPAPPLIST_ICON_FORMAT_SVG 0x0003
+
+#define RDPAPPLIST_FIELD_ID         0x00000001
+#define RDPAPPLIST_FIELD_GROUP      0x00000002
+#define RDPAPPLIST_FIELD_EXECPATH   0x00000004
+#define RDPAPPLIST_FIELD_DESC       0x00000008
+#define RDPAPPLIST_FIELD_ICON       0x00000010
+#define RDPAPPLIST_FIELD_PROVIDER   0x00000020
+#define RDPAPPLIST_FIELD_WORKINGDIR 0x00000040
+
+/* RDPAPPLIST_UPDATE_APPLIST_PDU */
+#define RDPAPPLIST_HINT_NEWID      0x00010000 /* new appId vs update existing appId. */
+#define RDPAPPLIST_HINT_SYNC       0x00100000 /* In sync mode (use with _NEWID). */
+#define RDPAPPLIST_HINT_SYNC_START 0x00200000 /* Sync appId start (use with _SYNC). */
+#define RDPAPPLIST_HINT_SYNC_END   0x00400000 /* Sync appId end (use with _SYNC). */
+/* Client should remove any app entry those are not reported between _START and _END during sync mode */
+
+#define RDPAPPLIST_HEADER_SIZE 8
+
+#define RDPAPPLIST_LANG_SIZE 32
+
+#define RDPAPPLIST_MAX_STRING_SIZE 512
+
+struct _RDPAPPLIST_HEADER
+{
+	UINT32 cmdId;
+	UINT32 length;
+};
+
+typedef struct _RDPAPPLIST_HEADER RDPAPPLIST_HEADER;
+
+struct _RDPAPPLIST_SERVER_CAPS_PDU
+{
+	UINT16 version;
+	RAIL_UNICODE_STRING appListProviderName; /* name of app list provider. */
+};
+
+typedef struct _RDPAPPLIST_SERVER_CAPS_PDU RDPAPPLIST_SERVER_CAPS_PDU;
+
+struct _RDPAPPLIST_CLIENT_CAPS_PDU
+{
+	UINT16 version;
+	/* ISO 639 (Language name) and ISO 3166 (Country name) connected with '_', such as en_US, ja_JP */
+	char clientLanguageId[RDPAPPLIST_LANG_SIZE];
+};
+
+typedef struct _RDPAPPLIST_CLIENT_CAPS_PDU RDPAPPLIST_CLIENT_CAPS_PDU;
+
+struct _RDPAPPLIST_ICON_DATA {
+	UINT32 flags;
+	UINT32 iconWidth;
+	UINT32 iconHeight;
+	UINT32 iconStride;
+	UINT32 iconBpp;
+	UINT32 iconFormat; /* RDPAPPLIST_ICON_FORMAT_* */
+	UINT32 iconBitsLength; /* size of buffer pointed by iconBits. */
+	VOID *iconBits; /* icon image data */
+			/* For BMP, image data only */
+			/* For PNG, entire PNG file including headers */
+			/* For SVG, entire SVG file including headers */
+		 	/* For 32bpp image, alpha-channel works as mask */
+};
+
+typedef struct _RDPAPPLIST_ICON_DATA RDPAPPLIST_ICON_DATA;
+
+/* Create or update application program link in client */
+
+struct _RDPAPPLIST_UPDATE_APPLIST_PDU
+{
+	UINT32 flags;
+	RAIL_UNICODE_STRING appId; /* Identifier of application to be added
+				      to client's Start Menu. This is used as
+				      the file name of link (.lnk) at Start Menu. */
+	RAIL_UNICODE_STRING appGroup; /* name of app group. */
+	RAIL_UNICODE_STRING appExecPath; /* Path to server side executable. */
+	RAIL_UNICODE_STRING appWorkingDir; /* Working directory to run the executable in. */
+	RAIL_UNICODE_STRING appDesc; /* UI friendly description of application. */
+	RDPAPPLIST_ICON_DATA *appIcon;
+};
+
+typedef struct _RDPAPPLIST_UPDATE_APPLIST_PDU RDPAPPLIST_UPDATE_APPLIST_PDU;
+
+/* Delete specififed application program link from client */
+
+struct _RDPAPPLIST_DELETE_APPLIST_PDU
+{
+	UINT32 flags;
+	RAIL_UNICODE_STRING appId; /* Identifier of application to be removed
+				      from client's Start Menu. */
+	RAIL_UNICODE_STRING appGroup; /* name of app group. */
+};
+
+typedef struct _RDPAPPLIST_DELETE_APPLIST_PDU RDPAPPLIST_DELETE_APPLIST_PDU;
+
+/* Delete all application program link under specififed provider from client */
+
+struct _RDPAPPLIST_DELETE_APPLIST_PROVIDER_PDU
+{
+	UINT32 flags;
+	RAIL_UNICODE_STRING appListProviderName; /* name of app list provider to be removed
+						    from client's Start Menu. */
+};
+
+typedef struct _RDPAPPLIST_DELETE_APPLIST_PROVIDER_PDU RDPAPPLIST_DELETE_APPLIST_PROVIDER_PDU;
+
+#endif /* FREERDP_CHANNEL_RDPAPPLIST_H */

--- a/rdpapplist/rdpapplist_server.h
+++ b/rdpapplist/rdpapplist_server.h
@@ -1,0 +1,73 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RDPXXXX Remote Application List Virtual Channel Extension
+ *
+ * Copyright 2020 Microsoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_RDPAPPLIST_SERVER_RDPAPPLIST_H
+#define FREERDP_CHANNEL_RDPAPPLIST_SERVER_RDPAPPLIST_H
+
+#include "rdpapplist_protocol.h"
+
+#include <freerdp/freerdp.h>
+#include <freerdp/api.h>
+#include <freerdp/types.h>
+
+typedef struct _rdpapplist_server_private RdpAppListServerPrivate;
+typedef struct _rdpapplist_server_context RdpAppListServerContext;
+
+typedef UINT (*psRdpAppListOpen)(RdpAppListServerContext* context);
+typedef UINT (*psRdpAppListClose)(RdpAppListServerContext* context);
+
+typedef UINT (*psRdpAppListCaps)(RdpAppListServerContext* context, const RDPAPPLIST_SERVER_CAPS_PDU *caps);
+typedef UINT (*psRdpAppListUpdate)(RdpAppListServerContext* context, const RDPAPPLIST_UPDATE_APPLIST_PDU *updateAppList);
+typedef UINT (*psRdpAppListDelete)(RdpAppListServerContext* context, const RDPAPPLIST_DELETE_APPLIST_PDU *deleteAppList);
+typedef UINT (*psRdpAppListDeleteProvider)(RdpAppListServerContext* context, const RDPAPPLIST_DELETE_APPLIST_PROVIDER_PDU *deleteAppListProvider);
+
+typedef UINT (*psRdpAppListClientCaps)(RdpAppListServerContext* context, const RDPAPPLIST_CLIENT_CAPS_PDU *clientCaps);
+
+struct _rdpapplist_server_context
+{
+	void* custom;
+	HANDLE vcm;
+
+	psRdpAppListOpen Open;
+	psRdpAppListClose Close;
+
+	psRdpAppListCaps ApplicationListCaps;
+	psRdpAppListUpdate UpdateApplicationList;
+	psRdpAppListDelete DeleteApplicationList;
+	psRdpAppListDeleteProvider DeleteApplicationListProvider;
+
+	psRdpAppListClientCaps ApplicationListClientCaps;
+
+	RdpAppListServerPrivate* priv;
+	rdpContext* rdpcontext;
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	FREERDP_API RdpAppListServerContext* rdpapplist_server_context_new(HANDLE vcm);
+	FREERDP_API void rdpapplist_server_context_free(RdpAppListServerContext* context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FREERDP_CHANNEL_RDPAPPLIST_SERVER_RDPAPPLIST_H */

--- a/rdpapplist/server/meson.build
+++ b/rdpapplist/server/meson.build
@@ -1,0 +1,29 @@
+dep_frdp_server = dependency('freerdp-server2', version: '>= 2.0.0', required: false)
+if not dep_frdp_server.found()
+    error('librapapplist-server requires freerdp2-server2 which was not found.')
+endif
+
+deps_librdpapplist_server = [
+    dep_frdp,
+    dep_frdp_server,
+    dep_winpr,
+]
+
+srcs_librdpapplist_server = [
+    '../rdpapplist_common.c',
+    'rdpapplist_main.c',
+]
+
+incs_common_server = [
+    '../',
+]
+
+plugin_rdpapplist_server = shared_library(
+    'librdpapplist-server',
+    srcs_librdpapplist_server,
+    include_directories: incs_common_server,
+    dependencies: deps_librdpapplist_server,
+    name_prefix: '',
+    install: true,
+    install_dir: install_lib_dir_rdpapplist,
+)

--- a/rdpapplist/server/rdpapplist_main.c
+++ b/rdpapplist/server/rdpapplist_main.c
@@ -1,0 +1,705 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RDPXXXX Remote Application List Virtual Channel Extension
+ *
+ * Copyright 2020 Microsoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "rdpapplist_main.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <winpr/crt.h>
+#include <winpr/synch.h>
+#include <winpr/thread.h>
+#include <winpr/stream.h>
+#include <winpr/sysinfo.h>
+#include <freerdp/channels/wtsvc.h>
+#include <freerdp/channels/log.h>
+
+#include "rdpapplist_server.h"
+#include "rdpapplist_common.h"
+
+#define TAG CHANNELS_TAG("rdpapplist.server")
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpapplist_recv_caps_pdu(wStream* s, RdpAppListServerContext* context)
+{
+	UINT32 error = CHANNEL_RC_OK;
+	RDPAPPLIST_CLIENT_CAPS_PDU pdu;
+
+	if (Stream_GetRemainingLength(s) < 2)
+	{
+		WLog_ERR(TAG, "not enough data!");
+		return ERROR_INVALID_DATA;
+	}
+
+	Stream_Read_UINT16(s, pdu.version); /* version (2 bytes) */
+	if (Stream_GetRemainingLength(s) < RDPAPPLIST_LANG_SIZE)
+	{
+		WLog_ERR(TAG, "not enough data!");
+		return ERROR_INVALID_DATA;
+	}
+	Stream_Read(s, &pdu.clientLanguageId[0], RDPAPPLIST_LANG_SIZE);
+
+	if (context)
+		IFCALLRET(context->ApplicationListClientCaps, error, context, &pdu);
+
+	return error;
+}
+
+static UINT rdpapplist_server_receive_pdu(RdpAppListServerContext* context, wStream* s)
+{
+	UINT error = CHANNEL_RC_OK;
+	size_t beg, end;
+	RDPAPPLIST_HEADER header;
+	beg = Stream_GetPosition(s);
+
+	if ((error = rdpapplist_read_header(s, &header)))
+	{
+		WLog_ERR(TAG, "rdpapplist_read_header failed with error %" PRIu32 "!", error);
+		return error;
+	}
+
+	switch (header.cmdId)
+	{
+		case RDPAPPLIST_CMDID_CAPS:
+			if ((error = rdpapplist_recv_caps_pdu(s, context)))
+				WLog_ERR(TAG,
+				         "rdpapplist_recv_caps_pdu "
+				         "failed with error %" PRIu32 "!",
+				         error);
+
+			break;
+
+		default:
+			error = CHANNEL_RC_BAD_PROC;
+			WLog_WARN(TAG, "Received unknown PDU type: %" PRIu32 "", header.cmdId);
+			break;
+	}
+
+	end = Stream_GetPosition(s);
+
+	if (end != (beg + header.length))
+	{
+		WLog_ERR(TAG, "Unexpected RDPAPPLIST pdu end: Actual: %d, Expected: %" PRIu32 "", end,
+		         (beg + header.length));
+		Stream_SetPosition(s, (beg + header.length));
+	}
+
+	return error;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpapplist_server_handle_messages(RdpAppListServerContext* context)
+{
+	DWORD BytesReturned;
+	void* buffer;
+	UINT ret = CHANNEL_RC_OK;
+	RdpAppListServerPrivate* priv = context->priv;
+	wStream* s = priv->input_stream;
+
+	/* Check whether the dynamic channel is ready */
+	if (!priv->isReady)
+	{
+		if (WTSVirtualChannelQuery(priv->rdpapplist_channel, WTSVirtualChannelReady, &buffer,
+		                           &BytesReturned) == FALSE)
+		{
+			if (GetLastError() == ERROR_NO_DATA)
+				return ERROR_NO_DATA;
+
+			WLog_ERR(TAG, "WTSVirtualChannelQuery failed");
+			return ERROR_INTERNAL_ERROR;
+		}
+
+		priv->isReady = *((BOOL*)buffer);
+		WTSFreeMemory(buffer);
+	}
+
+	/* Consume channel event only after the dynamic channel is ready */
+	if (priv->isReady)
+	{
+		Stream_SetPosition(s, 0);
+
+		if (!WTSVirtualChannelRead(priv->rdpapplist_channel, 0, NULL, 0, &BytesReturned))
+		{
+			if (GetLastError() == ERROR_NO_DATA)
+				return ERROR_NO_DATA;
+
+			WLog_ERR(TAG, "WTSVirtualChannelRead failed!");
+			return ERROR_INTERNAL_ERROR;
+		}
+
+		if (BytesReturned < 1)
+			return CHANNEL_RC_OK;
+
+		if (!Stream_EnsureRemainingCapacity(s, BytesReturned))
+		{
+			WLog_ERR(TAG, "Stream_EnsureRemainingCapacity failed!");
+			return CHANNEL_RC_NO_MEMORY;
+		}
+
+		if (WTSVirtualChannelRead(priv->rdpapplist_channel, 0, (PCHAR)Stream_Buffer(s), Stream_Capacity(s),
+		                          &BytesReturned) == FALSE)
+		{
+			WLog_ERR(TAG, "WTSVirtualChannelRead failed!");
+			return ERROR_INTERNAL_ERROR;
+		}
+
+		Stream_SetLength(s, BytesReturned);
+		Stream_SetPosition(s, 0);
+
+		while (Stream_GetPosition(s) < Stream_Length(s))
+		{
+			if ((ret = rdpapplist_server_receive_pdu(context, s)))
+			{
+				WLog_ERR(TAG,
+				         "rdpapplist_server_receive_pdu "
+				         "failed with error %" PRIu32 "!",
+				         ret);
+				return ret;
+			}
+		}
+	}
+
+	return ret;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static DWORD WINAPI rdpapplist_server_thread_func(LPVOID arg)
+{
+	RdpAppListServerContext* context = (RdpAppListServerContext*)arg;
+	RdpAppListServerPrivate* priv = context->priv;
+	DWORD status;
+	DWORD nCount;
+	HANDLE events[8];
+	UINT error = CHANNEL_RC_OK;
+	nCount = 0;
+	events[nCount++] = priv->stopEvent;
+	events[nCount++] = priv->channelEvent;
+
+	while (TRUE)
+	{
+		status = WaitForMultipleObjects(nCount, events, FALSE, INFINITE);
+
+		if (status == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForMultipleObjects failed with error %" PRIu32 "", error);
+			break;
+		}
+
+		/* Stop Event */
+		if (status == WAIT_OBJECT_0)
+			break;
+
+		if ((error = rdpapplist_server_handle_messages(context)))
+		{
+			WLog_ERR(TAG, "rdpapplist_server_handle_messages failed with error %" PRIu32 "", error);
+			break;
+		}
+	}
+
+	ExitThread(error);
+	return error;
+}
+
+/**
+ * Function description
+ * Create new stream for single rdpapplist packet. The new stream length
+ * would be required data length + header. The header will be written
+ * to the stream before return.
+ *
+ * @param cmdId
+ * @param length - data length without header
+ *
+ * @return new stream
+ */
+static wStream* rdpapplist_server_single_packet_new(UINT32 cmdId, UINT32 length)
+{
+	UINT error;
+	RDPAPPLIST_HEADER header;
+	wStream* s = Stream_New(NULL, RDPAPPLIST_HEADER_SIZE + length);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "Stream_New failed!");
+		goto error;
+	}
+
+	header.cmdId = cmdId;
+	header.length = RDPAPPLIST_HEADER_SIZE + length;
+
+	if ((error = rdpapplist_write_header(s, &header)))
+	{
+		WLog_ERR(TAG, "Failed to write header with error %" PRIu32 "!", error);
+		goto error;
+	}
+
+	return s;
+error:
+	Stream_Free(s, TRUE);
+	return NULL;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpapplist_server_packet_send(RdpAppListServerContext* context, wStream* s)
+{
+	UINT ret;
+	ULONG written;
+
+	if (!WTSVirtualChannelWrite(context->priv->rdpapplist_channel, (PCHAR)Stream_Buffer(s),
+	                            Stream_GetPosition(s), &written))
+	{
+		WLog_ERR(TAG, "WTSVirtualChannelWrite failed!");
+		ret = ERROR_INTERNAL_ERROR;
+		goto out;
+	}
+
+	if (written < Stream_GetPosition(s))
+	{
+		WLog_WARN(TAG, "Unexpected bytes written: %" PRIu32 "/%" PRIuz "", written,
+		          Stream_GetPosition(s));
+	}
+
+	ret = CHANNEL_RC_OK;
+out:
+	Stream_Free(s, TRUE);
+	return ret;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpapplist_send_caps(RdpAppListServerContext *context, const RDPAPPLIST_SERVER_CAPS_PDU *caps)
+{
+	if (caps->appListProviderName.length > RDPAPPLIST_MAX_STRING_SIZE)
+	{
+		WLog_ERR(TAG, "rdpapplist_send_caps: appProviderName is too large.");
+		return ERROR_INVALID_DATA;
+	}
+
+	int len = 2 + // version.
+		  2 + caps->appListProviderName.length;
+
+	wStream* s = rdpapplist_server_single_packet_new(RDPAPPLIST_CMDID_CAPS, len);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "rdpapplist_server_single_packet_new failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	Stream_Write_UINT16(s, caps->version);
+	Stream_Write_UINT16(s, caps->appListProviderName.length);
+	Stream_Write(s, caps->appListProviderName.string,
+	             caps->appListProviderName.length);
+	return rdpapplist_server_packet_send(context, s);
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpapplist_send_update_applist(RdpAppListServerContext* context, const RDPAPPLIST_UPDATE_APPLIST_PDU *updateAppList)
+{
+	UINT32 len = 4; // flags.
+	if (updateAppList->flags & RDPAPPLIST_FIELD_ID)
+	{
+		if (updateAppList->appId.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, "rdpapplist_send_update_applist: appId is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + updateAppList->appId.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_GROUP)
+	{
+		if (updateAppList->appGroup.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, "rdpapplist_send_update_applist: appGroup is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + updateAppList->appGroup.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_EXECPATH)
+	{
+		if (updateAppList->appExecPath.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, "rdpapplist_send_update_applist: appExecPath is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + updateAppList->appExecPath.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_WORKINGDIR)
+	{
+		if (updateAppList->appWorkingDir.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, "rdpapplist_send_update_applist: appWorkingDir is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + updateAppList->appWorkingDir.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_DESC)
+	{
+		if (updateAppList->appDesc.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, "rdpapplist_send_update_applist: appDesc is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + updateAppList->appDesc.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_ICON)
+	{
+		if (!updateAppList->appIcon)
+		{
+			WLog_ERR(TAG, "rdpapplist_send_update_applist icon flag is set, but appIcon is NULL.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (7 * 4 + updateAppList->appIcon->iconBitsLength);
+	}
+
+	wStream* s = rdpapplist_server_single_packet_new(RDPAPPLIST_CMDID_UPDATE_APPLIST, len);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "rdpapplist_server_single_packet_new failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	Stream_Write_UINT32(s, updateAppList->flags);
+	if (updateAppList->flags & RDPAPPLIST_FIELD_ID)
+	{
+		Stream_Write_UINT16(s, updateAppList->appId.length);
+		Stream_Write(s, updateAppList->appId.string,
+		             updateAppList->appId.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_GROUP)
+	{
+		Stream_Write_UINT16(s, updateAppList->appGroup.length);
+		Stream_Write(s, updateAppList->appGroup.string,
+		             updateAppList->appGroup.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_EXECPATH)
+	{
+		Stream_Write_UINT16(s, updateAppList->appExecPath.length);
+		Stream_Write(s, updateAppList->appExecPath.string,
+		             updateAppList->appExecPath.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_WORKINGDIR)
+	{
+		Stream_Write_UINT16(s, updateAppList->appWorkingDir.length);
+		Stream_Write(s, updateAppList->appWorkingDir.string,
+		             updateAppList->appWorkingDir.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_DESC)
+	{
+		Stream_Write_UINT16(s, updateAppList->appDesc.length);
+		Stream_Write(s, updateAppList->appDesc.string,
+		             updateAppList->appDesc.length);
+	}
+	if (updateAppList->flags & RDPAPPLIST_FIELD_ICON)
+	{
+		Stream_Write_UINT32(s, updateAppList->appIcon->flags);
+		Stream_Write_UINT32(s, updateAppList->appIcon->iconWidth);
+		Stream_Write_UINT32(s, updateAppList->appIcon->iconHeight);
+		Stream_Write_UINT32(s, updateAppList->appIcon->iconStride);
+		Stream_Write_UINT32(s, updateAppList->appIcon->iconBpp);
+		Stream_Write_UINT32(s, updateAppList->appIcon->iconFormat);
+		Stream_Write_UINT32(s, updateAppList->appIcon->iconBitsLength);
+		Stream_Write(s, updateAppList->appIcon->iconBits,
+			updateAppList->appIcon->iconBitsLength);
+	}
+
+	return rdpapplist_server_packet_send(context, s);
+}
+
+static UINT rdpapplist_send_delete_applist(RdpAppListServerContext* context, const RDPAPPLIST_DELETE_APPLIST_PDU *deleteAppList)
+{
+	UINT32 len = 4; // flags
+	if (deleteAppList->flags & RDPAPPLIST_FIELD_ID)
+	{
+		if (deleteAppList->appId.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, " rdpapplist_send_delete_applist: appId is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + deleteAppList->appId.length);
+	}
+	if (deleteAppList->flags & RDPAPPLIST_FIELD_GROUP)
+	{
+		if (deleteAppList->appGroup.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, " rdpapplist_send_delete_applist: appGroup is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + deleteAppList->appGroup.length);
+	}
+
+	wStream* s = rdpapplist_server_single_packet_new(RDPAPPLIST_CMDID_DELETE_APPLIST, len);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "rdpapplist_server_single_packet_new failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	Stream_Write_UINT32(s, deleteAppList->flags);
+	if (deleteAppList->flags & RDPAPPLIST_FIELD_ID)
+	{
+		Stream_Write_UINT16(s, deleteAppList->appId.length);
+		Stream_Write(s, deleteAppList->appId.string,
+		             deleteAppList->appId.length);
+	}
+	if (deleteAppList->flags & RDPAPPLIST_FIELD_GROUP)
+	{
+		Stream_Write_UINT16(s, deleteAppList->appGroup.length);
+		Stream_Write(s, deleteAppList->appGroup.string,
+		             deleteAppList->appGroup.length);
+	}
+	return rdpapplist_server_packet_send(context, s);
+}
+
+static UINT rdpapplist_send_delete_applist_provider(RdpAppListServerContext* context, const RDPAPPLIST_DELETE_APPLIST_PROVIDER_PDU *deleteAppListProvider)
+{
+	UINT32 len = 4; // flags.
+	if (deleteAppListProvider->flags & RDPAPPLIST_FIELD_PROVIDER)
+	{
+		if (deleteAppListProvider->appListProviderName.length > RDPAPPLIST_MAX_STRING_SIZE)
+		{
+			WLog_ERR(TAG, " rdpapplist_send_delete_applist: appProviderName is too large.");
+			return ERROR_INVALID_DATA;
+		}
+		len += (2 + deleteAppListProvider->appListProviderName.length);
+	}
+
+	wStream* s = rdpapplist_server_single_packet_new(RDPAPPLIST_CMDID_DELETE_APPLIST_PROVIDER, len);
+
+	if (!s)
+	{
+		WLog_ERR(TAG, "rdpapplist_server_single_packet_new failed!");
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	Stream_Write_UINT32(s, deleteAppListProvider->flags);
+	if (deleteAppListProvider->flags & RDPAPPLIST_FIELD_PROVIDER)
+	{
+		Stream_Write_UINT16(s, deleteAppListProvider->appListProviderName.length);
+		Stream_Write(s, deleteAppListProvider->appListProviderName.string,
+		             deleteAppListProvider->appListProviderName.length);
+	}
+	return rdpapplist_server_packet_send(context, s);
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpapplist_server_open(RdpAppListServerContext* context)
+{
+	UINT rc = ERROR_INTERNAL_ERROR;
+	RdpAppListServerPrivate* priv = context->priv;
+	DWORD BytesReturned = 0;
+	PULONG pSessionId = NULL;
+	void* buffer;
+	buffer = NULL;
+	priv->SessionId = WTS_CURRENT_SESSION;
+
+	if (WTSQuerySessionInformationA(context->vcm, WTS_CURRENT_SESSION, WTSSessionId,
+	                                (LPSTR*)&pSessionId, &BytesReturned) == FALSE)
+	{
+		WLog_ERR(TAG, "WTSQuerySessionInformationA failed!");
+		rc = ERROR_INTERNAL_ERROR;
+		goto out_close;
+	}
+
+	priv->SessionId = (DWORD)*pSessionId;
+	WTSFreeMemory(pSessionId);
+	priv->rdpapplist_channel = (HANDLE)WTSVirtualChannelOpenEx(priv->SessionId, RDPAPPLIST_DVC_CHANNEL_NAME,
+	                                                     WTS_CHANNEL_OPTION_DYNAMIC);
+
+	if (!priv->rdpapplist_channel)
+	{
+		WLog_ERR(TAG, "WTSVirtualChannelOpenEx failed!");
+		rc = GetLastError();
+		goto out_close;
+	}
+
+	/* Query for channel event handle */
+	if (!WTSVirtualChannelQuery(priv->rdpapplist_channel, WTSVirtualEventHandle, &buffer,
+	                            &BytesReturned) ||
+	    (BytesReturned != sizeof(HANDLE)))
+	{
+		WLog_ERR(TAG,
+		         "WTSVirtualChannelQuery failed "
+		         "or invalid returned size(%" PRIu32 ")",
+		         BytesReturned);
+
+		if (buffer)
+			WTSFreeMemory(buffer);
+
+		rc = ERROR_INTERNAL_ERROR;
+		goto out_close;
+	}
+
+	CopyMemory(&priv->channelEvent, buffer, sizeof(HANDLE));
+	WTSFreeMemory(buffer);
+
+	if (priv->thread == NULL)
+	{
+		if (!(priv->stopEvent = CreateEvent(NULL, TRUE, FALSE, NULL)))
+		{
+			WLog_ERR(TAG, "CreateEvent failed!");
+			rc = ERROR_INTERNAL_ERROR;
+		}
+
+		if (!(priv->thread =
+		          CreateThread(NULL, 0, rdpapplist_server_thread_func, (void*)context, 0, NULL)))
+		{
+			WLog_ERR(TAG, "CreateEvent failed!");
+			CloseHandle(priv->stopEvent);
+			priv->stopEvent = NULL;
+			rc = ERROR_INTERNAL_ERROR;
+		}
+	}
+
+	return CHANNEL_RC_OK;
+out_close:
+	WTSVirtualChannelClose(priv->rdpapplist_channel);
+	priv->rdpapplist_channel = NULL;
+	priv->channelEvent = NULL;
+	return rc;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT rdpapplist_server_close(RdpAppListServerContext* context)
+{
+	UINT error = CHANNEL_RC_OK;
+	RdpAppListServerPrivate* priv = context->priv;
+
+	if (priv->thread)
+	{
+		SetEvent(priv->stopEvent);
+
+		if (WaitForSingleObject(priv->thread, INFINITE) == WAIT_FAILED)
+		{
+			error = GetLastError();
+			WLog_ERR(TAG, "WaitForSingleObject failed with error %" PRIu32 "", error);
+			return error;
+		}
+
+		CloseHandle(priv->thread);
+		CloseHandle(priv->stopEvent);
+		priv->thread = NULL;
+		priv->stopEvent = NULL;
+	}
+
+	if (priv->rdpapplist_channel)
+	{
+		WTSVirtualChannelClose(priv->rdpapplist_channel);
+		priv->rdpapplist_channel = NULL;
+	}
+
+	return error;
+}
+
+RdpAppListServerContext* rdpapplist_server_context_new(HANDLE vcm)
+{
+	RdpAppListServerContext* context;
+	RdpAppListServerPrivate* priv;
+	context = (RdpAppListServerContext*)calloc(1, sizeof(RdpAppListServerContext));
+
+	if (!context)
+	{
+		WLog_ERR(TAG, "rdpapplist_server_context_new(): calloc RdpAppListServerContext failed!");
+		return NULL;
+	}
+
+	priv = context->priv = (RdpAppListServerPrivate*)calloc(1, sizeof(RdpAppListServerPrivate));
+
+	if (!context->priv)
+	{
+		WLog_ERR(TAG, "rdpapplist_server_context_new(): calloc RdpAppListServerPrivate failed!");
+		goto out_free;
+	}
+
+	priv->input_stream = Stream_New(NULL, 4);
+
+	if (!priv->input_stream)
+	{
+		WLog_ERR(TAG, "Stream_New failed!");
+		goto out_free_priv;
+	}
+
+	context->vcm = vcm;
+	context->Open = rdpapplist_server_open;
+	context->Close = rdpapplist_server_close;
+	context->ApplicationListCaps = rdpapplist_send_caps;
+	context->UpdateApplicationList = rdpapplist_send_update_applist;
+	context->DeleteApplicationList = rdpapplist_send_delete_applist;
+	context->DeleteApplicationListProvider = rdpapplist_send_delete_applist_provider;
+	priv->isReady = FALSE;
+	return context;
+out_free_priv:
+	free(context->priv);
+out_free:
+	free(context);
+	return NULL;
+}
+
+void rdpapplist_server_context_free(RdpAppListServerContext* context)
+{
+	if (!context)
+		return;
+
+	rdpapplist_server_close(context);
+
+	if (context->priv)
+	{
+		Stream_Free(context->priv->input_stream, TRUE);
+		free(context->priv);
+	}
+
+	free(context);
+}

--- a/rdpapplist/server/rdpapplist_main.h
+++ b/rdpapplist/server/rdpapplist_main.h
@@ -1,0 +1,37 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * RDPXXXX Remote Application List Virtual Channel Extension
+ *
+ * Copyright 2020 Microsoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FREERDP_CHANNEL_RDPAPPLIST_SERVER_MAIN_H
+#define FREERDP_CHANNEL_RDPAPPLIST_SERVER_MAIN_H
+
+#include <freerdp/server/gfxredir.h>
+
+struct _rdpapplist_server_private
+{
+	BOOL isReady;
+	wStream* input_stream;
+	HANDLE channelEvent;
+	HANDLE thread;
+	HANDLE stopEvent;
+	DWORD SessionId;
+
+	void* rdpapplist_channel;
+};
+
+#endif /* FREERDP_CHANNEL_RDPAPPLIST_SERVER_MAIN_H */


### PR DESCRIPTION
This PR adds rdpapplist which originally temporary placed at FreeRDP project. 

rdpapplist is the WSLg specific module, and it sends the application list from WSLg to Windows client for Start Menu.

This PR is focusing on building new so at WSLg tree, and there is a plan for more code sharing with its client side code at WSLDVCPlugin.