### PR TITLE
Fix Dockerfile error to auto install debug tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -275,7 +275,8 @@ RUN tdnf    install -y \
             xorg-x11-xtrans-devel
 
 # Install packages to aid in development.
-RUN if [ "$SYSTEMDISTRO_DEBUG_BUILD" == "true" ] ; then \
+ARG SYSTEMDISTRO_DEBUG_BUILD
+RUN if [ "$SYSTEMDISTRO_DEBUG_BUILD" = "true" ] ; then \
         tdnf install -y \
              gdb \
              nano \


### PR DESCRIPTION
This fix addresses the debug tools not being installed correctly when SYSTEMDISTRO_DEBUG_BUILD=true is specified. It redeclares the ARG since it's a new image than when it was previously declared and then does an "=" comparison. Docker uses /bin/sh (https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) which I believe is bash specific and not part of sh.