### PR TITLE
Update Edge DEB link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ sudo curl -L -o "./teams.deb" "https://teams.microsoft.com/downloads/desktopurl?
 sudo apt install ./teams.deb -y
 
 ## Microsoft Edge Browser
-sudo curl https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-dev/microsoft-edge-dev_91.0.852.0-1_amd64.deb -o /tmp/edge.deb
+sudo curl https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-dev/microsoft-edge-dev_93.0.946.1-1_amd64.deb -o /tmp/edge.deb
 sudo apt install /tmp/edge.deb -y
 ```
 


### PR DESCRIPTION
The previous link now points to a 404; this one should work for a while at the very least.

Ideally there would be a "latest" link (microsoft-edge-dev_latest_amd64.deb), which could point to the newest file in the microsoft-edge-dev folder, reducing the need to use links to specific versions and thus making the command not break so quickly.