### PR TITLE
Produce a .img file in addition to a .vhd for the system distro.

### DIFF
--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -20,8 +20,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </metadata>
   <files>
     <file src="Microsoft.WSLg.targets" target="build/Microsoft.WSLg.targets" />
+    <file src="package/system_x64.img" target="build/native/bin/x64/system.img" />
     <file src="package/system_x64.vhd" target="build/native/bin/x64/system.vhd" />
     <file src="package/WSLDVCPlugin_x64.dll" target="build/native/bin/x64/WSLDVCPlugin.dll" />
+    <file src="package/system_ARM64.img" target="build/native/bin/arm64/system.img" />
     <file src="package/system_ARM64.vhd" target="build/native/bin/arm64/system.vhd" />
     <file src="package/WSLDVCPlugin_ARM64.dll" target="build/native/bin/arm64/WSLDVCPlugin.dll" />
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />

--- a/Microsoft.WSLg.targets
+++ b/Microsoft.WSLg.targets
@@ -6,6 +6,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)native\bin\$(Platform)\system.img">
+      <Link>system.img</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="$(MSBuildThisFileDirectory)native\bin\$(Platform)\system.vhd">
       <Link>system.vhd</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,21 @@ stages:
           artifact: 'system_x64.vhd'
           publishLocation: 'pipeline'
 
+      - task: Go@0
+        inputs:
+          command: 'custom'
+          customCommand: 'run'
+          arguments: 'tar2ext4.go -i $(Agent.BuildDirectory)/system_x64.tar -o $(Agent.BuildDirectory)/system_x64.img'
+          workingDirectory: 'hcsshim/cmd/tar2ext4'
+        displayName: 'Create system_x64.img'
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish system_x64.img artifact'
+        inputs:
+          targetPath: $(Agent.BuildDirectory)/system_x64.img
+          artifact: 'system_x64.img'
+          publishLocation: 'pipeline'
+
       - task: PublishPipelineArtifact@1
         displayName: 'Publish system-distro-debuginfo-x64.tar.gz artifact'
         inputs:
@@ -207,6 +222,22 @@ stages:
         inputs:
           targetPath: $(Agent.BuildDirectory)/system_arm64.vhd
           artifact: 'system_arm64.vhd'
+          publishLocation: 'pipeline'
+
+      - task: Go@0
+        inputs:
+          command: 'custom'
+          customCommand: 'run'
+          arguments: 'tar2ext4.go -i $(Agent.BuildDirectory)/system_arm64.tar -o $(Agent.BuildDirectory)/system_arm64.img'
+          workingDirectory: 'hcsshim/cmd/tar2ext4'
+        displayName: 'Create system_arm64.img'
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish system_arm64.img artifact'
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        inputs:
+          targetPath: $(Agent.BuildDirectory)/system_arm64.img
+          artifact: 'system_arm64.img'
           publishLocation: 'pipeline'
 
       - script: mkdir ./dev &&


### PR DESCRIPTION
This change adds raw .img file creation to the build pipeline. This is needed because we are investigating switching to a readonly vPMEM device mounted with direct access to improve memory footprint of WSLg.

For testing I have run the pipeline internally on this branch and validated that it passes.