### PR TITLE
add weston_rdprail_shell to debuginfo list

### DIFF
--- a/debuginfo/weston.list
+++ b/debuginfo/weston.list
@@ -12,3 +12,4 @@ usr/lib/weston/rdprail-shell.so
 usr/lib/weston/systemd-notify.so
 usr/libexec/weston-desktop-shell
 usr/libexec/weston-keyboard
+usr/libexec/weston-rdprail-shell


### PR DESCRIPTION
add weston_rdprail_shell to debuginfo list, which is added by https://github.com/microsoft/weston-mirror/pull/35.