### PR TITLE
fix reading .wslgconfig from user profile path

### DIFF
--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -67,10 +67,10 @@ std::string TranslateWindowsPath(const char * Path)
     /* read single line from wslpath output */
     if (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         result += buffer.data();
-    }
-    /* trim '\n' from wslpath output */
-    while (result.back() == '\n') {
-        result.pop_back();
+        /* trim '\n' from wslpath output */
+        while (result.back() == '\n') {
+            result.pop_back();
+        }
     }
 
     THROW_ERRNO_IF(EINVAL, pclose(pipe.release()) != 0);

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -64,8 +64,13 @@ std::string TranslateWindowsPath(const char * Path)
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(commandLine.c_str(), "r"), pclose);
     THROW_LAST_ERROR_IF(!pipe);
 
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    /* read single line from wslpath output */
+    if (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         result += buffer.data();
+    }
+    /* trim '\n' from wslpath output */
+    while (result.back() == '\n') {
+        result.pop_back();
     }
 
     THROW_ERRNO_IF(EINVAL, pclose(pipe.release()) != 0);

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -64,13 +64,12 @@ std::string TranslateWindowsPath(const char * Path)
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(commandLine.c_str(), "r"), pclose);
     THROW_LAST_ERROR_IF(!pipe);
 
-    /* read single line from wslpath output */
-    if (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         result += buffer.data();
-        /* trim '\n' from wslpath output */
-        while (result.back() == '\n') {
-            result.pop_back();
-        }
+    }
+    /* trim '\n' from wslpath output */
+    while (result.back() == '\n') {
+        result.pop_back();
     }
 
     THROW_ERRNO_IF(EINVAL, pclose(pipe.release()) != 0);


### PR DESCRIPTION
fix reading .wslgconfig from user profile path. 

wslpath appends '\n' at end, so it has to be trimmed before appending .wslgconfig file name.