### PR TITLE
check for integer overflow / truncation

### DIFF
--- a/WSLDVCPlugin/WSLDVCCallback.cpp
+++ b/WSLDVCPlugin/WSLDVCCallback.cpp
@@ -5,6 +5,7 @@
 #include "rdpapplist.h"
 #include "WSLDVCCallback.h"
 #include "WSLDVCFileDB.h"
+#include <intsafe.h>
 
 LPCWSTR c_WSL_exe = L"%windir%\\system32\\wsl.exe";
 LPCWSTR c_WSLg_exe = L"%windir%\\system32\\wslg.exe";
@@ -173,13 +174,10 @@ public:
         ReadUINT32(iconData->iconFormat, cur, len);
         ReadUINT32(iconData->iconBitsLength, cur, len);
 
-        if (iconData->iconBitsLength + (UINT32)sizeof(ICON_HEADER) < iconData->iconBitsLength ||
-            iconData->iconBitsLength + (UINT32)sizeof(ICON_HEADER) + (UINT32)sizeof(BITMAPINFOHEADER) < iconData->iconBitsLength)
-        {
-            return E_FAIL;
+        if (UIntAdd(sizeof(ICON_HEADER) + sizeof(BITMAPINFOHEADER), iconData->iconBitsLength, &iconData->iconFileSize) != S_OK) {
+	        return E_FAIL;
         }
         
-        iconData->iconFileSize = sizeof(ICON_HEADER) + sizeof(BITMAPINFOHEADER) + iconData->iconBitsLength;
         iconData->iconFileData = (BYTE*)LocalAlloc(LPTR, iconData->iconFileSize);
         if (!iconData->iconFileData)
         {

--- a/WSLDVCPlugin/WSLDVCCallback.cpp
+++ b/WSLDVCPlugin/WSLDVCCallback.cpp
@@ -173,6 +173,12 @@ public:
         ReadUINT32(iconData->iconFormat, cur, len);
         ReadUINT32(iconData->iconBitsLength, cur, len);
 
+        if (iconData->iconBitsLength + (UINT32)sizeof(ICON_HEADER) < iconData->iconBitsLength ||
+            iconData->iconBitsLength + (UINT32)sizeof(ICON_HEADER) + (UINT32)sizeof(BITMAPINFOHEADER) < iconData->iconBitsLength)
+        {
+            return E_FAIL;
+        }
+        
         iconData->iconFileSize = sizeof(ICON_HEADER) + sizeof(BITMAPINFOHEADER) + iconData->iconBitsLength;
         iconData->iconFileData = (BYTE*)LocalAlloc(LPTR, iconData->iconFileSize);
         if (!iconData->iconFileData)


### PR DESCRIPTION
if iconData->iconBitsLength is large enough iconData->iconFileSize could be truncated, which would result in an allocation that is way too small. Memory corruption would follow. You probably get lucky on that 2nd part, since  ReadBYTES() probably bails out before any copy occurs. Although MSDN does say: "There is no hard limit on the size of the data that can be sent", so maybe it could corrupt memory if ~4gig of data is send over the channel.