### PR TITLE
Fix Typo in Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ The WSLg system distro is built using docker build. We essentially start from a 
     git clone https://github.com/microsoft/wslg wslg
 ```
 
-2. Clone the FreeRDP, Weston and PulseAudio mirror. These need to be located in a **vendor** sub-directory where you clone the wslg project (e.g. wslg/vendor), this is where our docker build script expect to find the source code. Make sure to checkout the **working** branch from each of these projects, the **main** branch references the upstream code.
+2. Clone the FreeRDP, Weston and PulseAudio mirror. These need to be located in a **vendor** sub-directory where you clone the wslg project (e.g. wslg/vendor), this is where our docker build script expects to find the source code. Make sure to checkout the **working** branch from each of these projects, the **main** branch references the upstream code.
 
     ```bash
     git clone https://github.com/microsoft/FreeRDP-mirror wslg/vendor/FreeRDP -b working


### PR DESCRIPTION
I fixed a type where CONTRIBUTING.md said "our docker build script expect to" as opposed to "our docker build script expects to".