### PR TITLE
Add system distro debuginfo and RDP plugin PDB to nuget package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -279,8 +279,8 @@ RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
 # Gather debuginfo to a tar file
 WORKDIR /work/debuginfo
 RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
-        echo "== Compress debug info: /work/debuginfo/system-distro-debuginfo.tar.gz ==" && \
-        tar -C /work/build/debuginfo -czf system-distro-debuginfo.tar.gz ./ ; \
+        echo "== Compress debug info: /work/debuginfo/system-debuginfo.tar.gz ==" && \
+        tar -C /work/build/debuginfo -czf system-debuginfo.tar.gz ./ ; \
     fi
 
 ########################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -324,14 +324,11 @@ RUN echo "== Install Core/UI Runtime Dependencies ==" && \
 # Install packages to aid in development, if not remove some packages. 
 ARG SYSTEMDISTRO_DEBUG_BUILD
 RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
-        rpm -e --nodeps python2                  \
         rpm -e --nodeps curl                     \
-        rpm -e --nodeps python-xml               \
         rpm -e --nodeps pkg-config               \
         rpm -e --nodeps vim                      \
         rpm -e --nodeps wget                     \
-        rpm -e --nodeps python3                  \
-        rpm -e --nodeps python2-libs;            \
+        rpm -e --nodeps python3;                 \
     else                                         \
         echo "== Install development aid packages ==" && \
         tdnf install -y                          \

--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -22,12 +22,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <file src="Microsoft.WSLg.targets" target="build/Microsoft.WSLg.targets" />
     <file src="package/system_x64.img" target="build/native/bin/x64/system.img" />
     <file src="package/system_x64.vhd" target="build/native/bin/x64/system.vhd" />
+    <file src="package/system-debuginfo_x64.tar.gz" target="build/native/bin/x64/system-debuginfo.tar.gz" />
     <file src="package/WSLDVCPlugin_x64.dll" target="build/native/bin/x64/WSLDVCPlugin.dll" />
     <file src="package/WSLDVCPlugin_x64.pdb" target="build/native/bin/x64/WSLDVCPlugin.pdb" />
     <file src="package/system_ARM64.img" target="build/native/bin/arm64/system.img" />
     <file src="package/system_ARM64.vhd" target="build/native/bin/arm64/system.vhd" />
+    <file src="package/system-debuginfo_ARM64.tar.gz" target="build/native/bin/arm64/system-debuginfo.tar.gz" />
     <file src="package/WSLDVCPlugin_ARM64.dll" target="build/native/bin/arm64/WSLDVCPlugin.dll" />
     <file src="package/WSLDVCPlugin_ARM64.pdb" target="build/native/bin/arm64/WSLDVCPlugin.pdb" />
+
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />
   </files>
 </package>

--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -23,9 +23,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <file src="package/system_x64.img" target="build/native/bin/x64/system.img" />
     <file src="package/system_x64.vhd" target="build/native/bin/x64/system.vhd" />
     <file src="package/WSLDVCPlugin_x64.dll" target="build/native/bin/x64/WSLDVCPlugin.dll" />
+    <file src="package/WSLDVCPlugin_x64.pdb" target="build/native/bin/x64/WSLDVCPlugin.pdb" />
     <file src="package/system_ARM64.img" target="build/native/bin/arm64/system.img" />
     <file src="package/system_ARM64.vhd" target="build/native/bin/arm64/system.vhd" />
     <file src="package/WSLDVCPlugin_ARM64.dll" target="build/native/bin/arm64/WSLDVCPlugin.dll" />
+    <file src="package/WSLDVCPlugin_ARM64.pdb" target="build/native/bin/arm64/WSLDVCPlugin.pdb" />
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />
   </files>
 </package>

--- a/Microsoft.WSLg.targets
+++ b/Microsoft.WSLg.targets
@@ -18,6 +18,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Link>WSLDVCPlugin.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)native\bin\$(Platform)\WSLDVCPlugin.pdb">
+      <Link>WSLDVCPlugin.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="$(MSBuildThisFileDirectory)native\bin\wslg.rdp">
       <Link>wslg.rdp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Microsoft.WSLg.targets
+++ b/Microsoft.WSLg.targets
@@ -18,10 +18,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Link>WSLDVCPlugin.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(MSBuildThisFileDirectory)native\bin\$(Platform)\WSLDVCPlugin.pdb">
-      <Link>WSLDVCPlugin.pdb</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Include="$(MSBuildThisFileDirectory)native\bin\wslg.rdp">
       <Link>wslg.rdp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,11 +66,8 @@ stages:
                 --target dev
         displayName: 'Create System Distro Dev Docker image Mariner-x64'
 
-      - script: docker cp `docker create system-distro-dev-x64 /bin/bash`:/work/debuginfo/system-distro-debuginfo.tar.gz $(Agent.BuildDirectory)
-        displayName: 'Copy system-distro-debuginfo.tar.gz'
-
-      - script: mv $(Agent.BuildDirectory)/system-distro-debuginfo.tar.gz $(Agent.BuildDirectory)/system-distro-debuginfo-x64.tar.gz
-        displayName: 'Rename system-distro-debuginfo-x64.tar.gz'
+      - script: docker cp `docker create system-distro-dev-x64 /bin/bash`:/work/debuginfo/system-debuginfo.tar.gz $(Agent.BuildDirectory)/system-debuginfo_x64.tar.gz
+        displayName: 'Copy system-debuginfo_x64.tar.gz'
 
       - task: Go@0
         inputs:
@@ -103,10 +100,10 @@ stages:
           publishLocation: 'pipeline'
 
       - task: PublishPipelineArtifact@1
-        displayName: 'Publish system-distro-debuginfo-x64.tar.gz artifact'
+        displayName: 'Publish system-debuginfo_x64.tar.gz artifact'
         inputs:
-          targetPath: $(Agent.BuildDirectory)/system-distro-debuginfo-x64.tar.gz
-          artifact: 'system-distro-debuginfo-x64.tar.gz'
+          targetPath: $(Agent.BuildDirectory)/system-debuginfo_x64.tar.gz
+          artifact: 'system-debuginfo_x64.tar.gz'
           publishLocation: 'pipeline'
           
   - job: 'Build_Windows_x64'
@@ -139,15 +136,18 @@ stages:
         platform: 'x64'
         configuration: 'Release'
 
+    - script: 'MOVE WSLDVCPlugin\x64\Release\WSLDVCPlugin.pdb package\WSLDVCPlugin_x64.pdb'
+      displayName: 'Move plugin PDB to package (x64)'
+
     - task: PublishPipelineArtifact@1
-      displayName: 'Publish WSLDVCPlugin pdb (x64)'
+      displayName: 'Publish WSLDVCPlugin PDB (x64)'
       inputs:
-        targetPath: WSLDVCPlugin\x64\Release\WSLDVCPlugin.pdb
+        targetPath: package\WSLDVCPlugin_x64.pdb
         artifact: 'WSLDVCPlugin.x64.pdb'
         publishLocation: 'pipeline'
 
     - script: 'MOVE WSLDVCPlugin\x64\Release\WSLDVCPlugin.dll package\WSLDVCPlugin_x64.dll'
-      displayName: 'Move plugin to package (x64)'
+      displayName: 'Move plugin DLL to package (x64)'
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish WSLDVCPlugin DLL (x64)'
@@ -249,14 +249,14 @@ stages:
                 --build-arg WSLG_VERSION=`gitversion /targetpath ./wslg /showvariable InformationalVersion` 
                 --build-arg WSLG_ARCH=aarch64 &&
                 tar -xvf ./dev/dev_build.tar -C ./dev/ &&
-                mv ./dev/work/debuginfo/system-distro-debuginfo.tar.gz $(Agent.BuildDirectory)/system-distro-debuginfo-arm64.tar.gz
-        displayName: 'Copy system-distro-debuginfo-arm64.tar.gz'
+                mv ./dev/work/debuginfo/system-debuginfo.tar.gz $(Agent.BuildDirectory)/system-debuginfo_arm64.tar.gz
+        displayName: 'Copy system-debuginfo_arm64.tar.gz'
 
       - task: PublishPipelineArtifact@1
-        displayName: 'Publish system-distro-debuginfo-arm64.tar.gz artifact'
+        displayName: 'Publish system-debuginfo_arm64.tar.gz artifact'
         inputs:
-          targetPath: $(Agent.BuildDirectory)/system-distro-debuginfo-arm64.tar.gz
-          artifact: 'system-distro-debuginfo-arm64.tar.gz'
+          targetPath: $(Agent.BuildDirectory)/system-debuginfo_arm64.tar.gz
+          artifact: 'system-debuginfo_arm64.tar.gz'
           publishLocation: 'pipeline'
 
   - job: 'Build_Windows_ARM64'
@@ -290,10 +290,13 @@ stages:
         platform: 'ARM64'
         configuration: 'Release'
 
+    - script: 'MOVE WSLDVCPlugin\ARM64\Release\WSLDVCPlugin.pdb package\WSLDVCPlugin_ARM64.pdb'
+      displayName: 'Move plugin PDB to package (ARM64)'
+
     - task: PublishPipelineArtifact@1
-      displayName: 'Publish WSLDVCPlugin pdb (ARM64)'
+      displayName: 'Publish WSLDVCPlugin PDB (ARM64)'
       inputs:
-        targetPath: WSLDVCPlugin\ARM64\Release\WSLDVCPlugin.pdb
+        targetPath: package\WSLDVCPlugin_ARM64.pdb
         artifact: 'WSLDVCPlugin.ARM64.pdb'
         publishLocation: 'pipeline'
 
@@ -332,12 +335,26 @@ stages:
           buildType: 'current'
           artifactName: 'system_x64.img'
           targetPath: 'package/'
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download system-debuginfo_x64.tar.gz'
+        inputs:
+          buildType: 'current'
+          artifactName: 'system-debuginfo_x64.tar.gz'
+          targetPath: 'package/'
           
       - task: DownloadPipelineArtifact@2
         displayName: 'Download WSLDVCPlugin DLL (x64)'
         inputs:
           buildType: 'current'
           artifactName: 'WSLDVCPlugin.x64.dll'
+          targetPath: 'package/'
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download WSLDVCPlugin PDB (x64)'
+        inputs:
+          buildType: 'current'
+          artifactName: 'WSLDVCPlugin.x64.pdb'
           targetPath: 'package/'
 
       - task: DownloadPipelineArtifact@2
@@ -355,10 +372,24 @@ stages:
           targetPath: 'package/'
 
       - task: DownloadPipelineArtifact@2
+        displayName: 'Download system-debuginfo_arm64.tar.gz'
+        inputs:
+          buildType: 'current'
+          artifactName: 'system-debuginfo_arm64.tar.gz'
+          targetPath: 'package/'
+
+      - task: DownloadPipelineArtifact@2
         displayName: 'Download WSLDVCPlugin DLL (ARM64)'
         inputs:
           buildType: 'current'
           artifactName: 'WSLDVCPlugin.ARM64.dll'
+          targetPath: 'package/'
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download WSLDVCPlugin PDB (ARM64)'
+        inputs:
+          buildType: 'current'
+          artifactName: 'WSLDVCPlugin.ARM64.pdb'
           targetPath: 'package/'
 
       - task: PowerShell@2


### PR DESCRIPTION
This allows build pipeline to preserve debug symbols within released nuget package.

note: WSLg utilize nuget package as archive format to hand off build artifacts between build pipelines, in this case between WSLg and wsl-build, the outcome nuget is not really expected to be installed directly from itself, thus including symbols in nuget package does not mean symbols are included in final WSL package (or installed). But since the WSLg feed preserves all released nuget, this allows us to locate corresponding symbols even after build artifacts are removed from build pipeline.  