### PR TITLE
Use dedicated RDP plugin registration for lifted WSL

### DIFF
--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -344,7 +344,7 @@ try {
         std::move(serviceId),
         "/silent",
         "/wslg",
-        "/plugin:WSLDVC",
+        isWslInstallPathEnvPresent ? "/plugin:WSLDVC_PACKAGE" : "/plugin:WSLDVC",
         std::move(sharedMemoryObPath),
         std::move(rdpFilePath)
     });


### PR DESCRIPTION
Use dedicated RDP plugin registration for lifted WSL to avoid interference between inbox WSL and lifted WSL. 