### PR TITLE
use doube-quote to wrap wslpath parameter

### DIFF
--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -59,9 +59,9 @@ std::string ToServiceId(unsigned int port)
 
 std::string TranslateWindowsPath(const char * Path)
 {
-    std::string commandLine = "/usr/bin/wslpath -a '";
+    std::string commandLine = "/usr/bin/wslpath -a \"";
     commandLine += Path;
-    commandLine += "'";
+    commandLine += "\"";
     std::array<char, 128> buffer;
     std::string result;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(commandLine.c_str(), "r"), pclose);


### PR DESCRIPTION
use doube-quote to wrap wslpath parameter. This is to address the issue reported at https://github.com/microsoft/wslg/issues/689, using double-quote (") is safe as it is not valid character as Windows file path while single-quote (') is valid.