### PR TITLE
add librsrg to enable SVG icon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN echo "== Install Core dependencies ==" && \
         libltdl  \
         libltdl-devel  \
         libpng-devel  \
+        librsvg2 \
+        librsvg2-devel \
         libtiff  \
         libtiff-devel  \
         libusb  \
@@ -304,6 +306,7 @@ RUN echo "== Install Core/UI Runtime Dependencies ==" && \
             libjpeg-turbo \
             libltdl \
             libpng \
+            librsvg2 \
             libsndfile \
             libwayland-client \
             libwayland-server \


### PR DESCRIPTION
Based on #70 ,  #657. The SVG icon format has been supported but disabled by default because lack of librsvg2 lib. This [issue](https://github.com/microsoft/CBL-Mariner/issues/1599) reports  librsvg has been added to Microsoft Mariner repository, so lib can be added to runtime image now.

Attention: This will not show your SVG icons in WSLg because the weston runtime has hard coded the icon path in /rpdrail-shell/app-list.c as the following code shows:

```
char *icon_folder[] = {
	"/usr/share/pixmaps/",
	"/usr/share/icons/hicolor/96x96/apps/",
	"/usr/share/icons/hicolor/128x128/apps/",
	"/usr/share/icons/hicolor/48x48/apps/",
	"/usr/share/icons/hicolor/32x32/apps/",
	"/usr/share/icons/hicolor/24x24/apps/",
	"/usr/share/icons/hicolor/22x22/apps/",
	"/usr/share/icons/hicolor/16x16/apps/",
	"/usr/share/icons/HighContrast/96x96/apps/",
	"/usr/share/icons/HighContrast/128x128/apps/",
	"/usr/share/icons/HighContrast/48x48/apps/",
	"/usr/share/icons/HighContrast/32x32/apps/",
	"/usr/share/icons/HighContrast/24x24/apps/",
	"/usr/share/icons/HighContrast/22x22/apps/",
	"/usr/share/icons/HighContrast/16x16/apps/",
	"/usr/share/icons/hicolor/scalable/apps/", /* use scalable(= svg) only when no png. */
	"/usr/share/icons/HighContrast/scalable/apps/", /* use scalable (= svg) only when no png. */
};
```
But you can change the source code and recompile it. Once you did that, the SVG icon will display. So this PR only add missing runtime libs.

Here are the SVG icons displayed in Win11 start menu:
![image](https://user-images.githubusercontent.com/2093588/162415665-a83eca6a-fc5b-42d4-9189-26fe6078c597.png)
