### PR TITLE
Tell customers to grab WSLG from Windows Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WSLg strives to make Linux GUI applications feel native and natural to use on Wi
 ## Pre-requisites
 
 - Windows 11 (build 22000.*) or Windows 11 Insider Preview (builds 21362+)
-   - WSLg is going to be generally available alongside the upcoming release of Windows. To get access to a preview of WSLg, you'll need to join the [Windows Insider Program](https://insider.windows.com/en-us/) and be running a Windows 11 Insider Preview build from the beta or dev channels.
+   - WSLg is going to be generally available alongside the upcoming release of Windows. To get access to a preview of WSLg, you'll need to install the [Windows Subsystem for Linux **Preview** from the Microsoft Store](https://aka.ms/wslstorepage).
 
 - It is recommended to run WSLg on a system with virtual GPU (vGPU) enabled for WSL so that you can benefit from hardware accelerated OpenGL rendering. You can find preview drivers supporting WSL from each of our partners below.
 


### PR DESCRIPTION
Since [WSL Preview is now available from Windows Store and includes WSLG by default](https://devblogs.microsoft.com/commandline/a-preview-of-wsl-in-the-microsoft-store-is-now-available/), this is a much more convenient path for obtaining WSLG than asking customers to switch to the Insiders Program (it's a much smaller ask).

I would also encourage you to change the wording in the Releases page to include this - novices who don't bother to read the README all the way through will tend to think that WSLG is something they can just install with the MSI on Windows 11 from the Releases page, which is not the case.