### PR TITLE
Add chrony to system distro to sync guest clock with the host via /dev/ptp0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -296,6 +296,7 @@ RUN echo "== Install mariner-repos-ui REPO ==" && \
 
 RUN echo "== Install Core/UI Runtime Dependencies ==" && \
     tdnf    install -y \
+            chrony \
             dbus \
             dbus-glib \
             dhcp-client \


### PR DESCRIPTION
To ensure the system clock does not drift from the host, WSL is planning on using chronyd with /dev/ptp0 as a clock source.