### PR TITLE
build DirectX-headers from specific version source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ The WSLg system distro is built using docker build. We essentially start from a 
     git clone https://github.com/microsoft/weston-mirror wslg/vendor/weston -b working
     git clone https://github.com/microsoft/PulseAudio-mirror wslg/vendor/pulseaudio -b working
     git clone https://github.com/mesa3d/mesa wslg/vendor/mesa -b 21.0
+    git clone https://github.com/microsoft/DirectX-Headers.git wslg/vendor/DirectX-Headers-1.0 -b v1.602.0-r1
     ```
 
 2. Create the VHD:

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN echo "== System distro build type (FreeRDP):" ${BUILDTYPE_FREERDP} " =="
 ENV DESTDIR=/work/build
 ENV PREFIX=/usr
 ENV PKG_CONFIG_PATH=${DESTDIR}${PREFIX}/lib/pkgconfig:${DESTDIR}${PREFIX}/lib/${WSLG_ARCH}-linux-gnu/pkgconfig:${DESTDIR}${PREFIX}/share/pkgconfig
-ENV C_INCLUDE_PATH=${DESTDIR}${PREFIX}/include/freerdp${FREERDP_VERSION}:${DESTDIR}${PREFIX}/include/winpr${FREERDP_VERSION}:${DESTDIR}${PREFIX}/include
+ENV C_INCLUDE_PATH=${DESTDIR}${PREFIX}/include/freerdp${FREERDP_VERSION}:${DESTDIR}${PREFIX}/include/winpr${FREERDP_VERSION}:${DESTDIR}${PREFIX}/include/wsl/stubs:${DESTDIR}${PREFIX}/include
 ENV CPLUS_INCLUDE_PATH=${C_INCLUDE_PATH}
 ENV LIBRARY_PATH=${DESTDIR}${PREFIX}/lib
 ENV LD_LIBRARY_PATH=${LIBRARY_PATH}
@@ -159,6 +159,15 @@ ENV CXX=/usr/bin/g++
 # Setup DebugInfo folder
 COPY debuginfo /work/debuginfo
 RUN chmod +x /work/debuginfo/gen_debuginfo.sh
+
+# Build DirectX-Headers
+COPY vendor/DirectX-Headers-1.0 /work/vendor/DirectX-Headers-1.0
+WORKDIR /work/vendor/DirectX-Headers-1.0
+RUN /usr/bin/meson --prefix=${PREFIX} build \
+        --buildtype=${BUILDTYPE_NODEBUGSTRIP} \
+        -Dbuild-test=false && \
+    ninja -C build -j8 install && \
+    echo 'mesa:' `git --git-dir=/work/vendor/DirectX-Headers-1.0/.git rev-parse --verify HEAD` >> /work/versions.txt
 
 # Build mesa with the minimal options we need.
 COPY vendor/mesa /work/vendor/mesa

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,11 +44,16 @@ stages:
                 tar -xvf mesa-21.0.0.tar.xz
         displayName: 'Download Mesa from CBL Mariner'
 
+      - script: wget https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.602.0-r1.tar.gz &&
+                tar -xvf v1.602.0-r1.tar.gz
+        displayName: 'Download DirectX-Headers from GitHub'
+
       - script: mv FreeRDP-mirror/ wslg/vendor/FreeRDP &&
                 mv weston-mirror/ wslg/vendor/weston &&
                 mv pulseaudio-mirror/ wslg/vendor/pulseaudio &&
-                mv mesa-21.0.0/ wslg/vendor/mesa
-        displayName: 'Move sub projects (FreeRDP, Weston, PulseAudio, Mesa)'
+                mv mesa-21.0.0/ wslg/vendor/mesa &&
+                mv DirectX-Headers-1.602.0-r1/ wslg/vendor/DirectX-Headers-1.0
+        displayName: 'Move sub projects (FreeRDP, Weston, PulseAudio, Mesa, DirectX-Headers)'
 
       - script: docker build -f ./wslg/Dockerfile -t system-distro-x64 
                 ./wslg 


### PR DESCRIPTION
build DirectX-headers from specific version source. This is because, by default, mesa is building from 'head'. https://gitlab.freedesktop.org/mesa/mesa/-/blob/21.0/subprojects/DirectX-Headers.wrap#L5