### PR TITLE
Add e2fsprogs to runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -306,6 +306,7 @@ RUN echo "== Install Core/UI Runtime Dependencies ==" && \
             dbus \
             dbus-glib \
             dhcp-client \
+            e2fsprogs \
             freefont \
             libinput \
             libjpeg-turbo \


### PR DESCRIPTION
With the change to Mariner 2.0 it looks like e2fsprogs is no longer included by default. This is needed by WSL to format the distro file system.