### PR TITLE
Add /usr/share/fonts/X11/misc to /etc/X11/xorg.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -366,6 +366,7 @@ RUN useradd -u 1000 --create-home wslg && \
 COPY config/wsl.conf /etc/wsl.conf
 COPY config/weston.ini /home/wslg/.config/weston.ini
 COPY config/local.conf /etc/fonts/local.conf
+COPY config/xorg.conf /etc/X11/xorg.conf
 
 # Copy default icon file.
 COPY resources/linux.png /usr/share/icons/wsl/linux.png

--- a/config/xorg.conf
+++ b/config/xorg.conf
@@ -1,0 +1,3 @@
+Section "Files"
+        FontPath     "/usr/share/fonts/X11/misc"
+EndSection


### PR DESCRIPTION
This change will allow WSLg to use fonts that are present on the user distro in addition to fonts available on Windows.