### PR TITLE
Update /etc/wsl.conf to set the default user to wslg

### DIFF
--- a/config/wsl.conf
+++ b/config/wsl.conf
@@ -1,2 +1,4 @@
 [boot]
 command=/usr/bin/WSLGd
+[user]
+default=wslg


### PR DESCRIPTION
This change modifies the default user of the system distro to the wslg user. This means that when running `wsl.exe --system` the wslg user will be used instead of root. You can still run as the root user by using `wsl.exe --system -u root`