### PR TITLE
enable xfonts from user distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -331,6 +331,7 @@ RUN echo "== Install Core/UI Runtime Dependencies ==" && \
             wayland-protocols-devel \
             xcursor-themes \
             xorg-x11-server-Xwayland \
+            xorg-x11-server-utils \
             xorg-x11-xtrans-devel
 
 # Install packages to aid in development, if not remove some packages. 

--- a/WSLGd/FontMonitor.cpp
+++ b/WSLGd/FontMonitor.cpp
@@ -1,0 +1,236 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+#include "FontMonitor.h"
+#include "common.h"
+
+constexpr auto c_fontMonitorRootPath = "/mnt/wslg/fonts/X11/";
+constexpr auto c_fontsdir = "fonts.dir";
+constexpr auto c_xset = "/usr/bin/xset";
+
+wslgd::FontFolder::FontFolder(int fd, const char *path)
+{
+    LOG_INFO("FontMonitor: start monitoring %s", path);
+
+    m_fd = fd;
+    m_path = path;
+
+    /* check if folder is already ready to be added to font path */
+    std::string fonts_dir(path);
+    fonts_dir += "/";
+    fonts_dir += c_fontsdir;
+    if (access(fonts_dir.c_str(), R_OK) == 0) {
+        ModifyX11FontPath(true);
+    } else {
+        /* if the file does not exist nor accessible, add watch */
+        LOG_INFO("FontMonitor: %s is not accessible, adding watch", fonts_dir.c_str());
+        m_wd = inotify_add_watch(m_fd, path, IN_CREATE|IN_DELETE|IN_MOVED_TO|IN_MOVED_FROM);
+        if (m_wd < 0) {
+            /* if failed, nothing can be done, just log error */
+            LOG_ERROR("FontMonitor: failed to add watch %s %s", path, strerror(errno));
+        }
+    }
+}
+
+wslgd::FontFolder::~FontFolder()
+{
+    LOG_INFO("FontMonitor: stop monitoring %s", m_path.c_str());
+
+    if (m_isPathAdded) {
+        ModifyX11FontPath(false);
+    }
+
+    /* if still under watch, remove it */
+    if (m_wd >= 0) {
+        inotify_rm_watch(m_fd, m_wd);
+        m_wd = -1;
+    }
+}
+
+void wslgd::FontFolder::ModifyX11FontPath(bool toAdd)
+{
+    std::string cmd(c_xset);
+    if (toAdd)
+       cmd += " +fp ";
+    else
+       cmd += " -fp ";
+    cmd += m_path;
+    LOG_INFO("FontMonitor: execuate %s", cmd.c_str());
+    system(cmd.c_str());
+    m_isPathAdded = toAdd;
+    LOG_INFO("FontMonitor: %s is %s from X11 font path",
+        m_path.c_str(), m_isPathAdded ? "added" : "removed");
+}
+
+wslgd::FontMonitor::FontMonitor()
+{
+}
+
+void wslgd::FontMonitor::DumpMonitorFolders()
+{
+    std::map<std::string, std::unique_ptr<FontFolder>>::iterator it;
+    for (it = m_fontMonitorFolders.begin(); it != m_fontMonitorFolders.end(); it++)
+        LOG_INFO("FontMonitor: monitoring %s, and it is %s to X11 font path", it->first.c_str(),
+            it->second->IsPathAdded() ? "added" : "*not* added");
+}
+
+void wslgd::FontMonitor::AddMonitorFolder(const char *path)
+{
+    std::string monitorPath(path);
+    // checkf if path is tracked already.
+    if (m_fontMonitorFolders.find(monitorPath) == m_fontMonitorFolders.end()) {
+        std::unique_ptr<FontFolder> fontFolder(new FontFolder(m_fd, path));
+        m_fontMonitorFolders.insert(std::make_pair(std::move(monitorPath), std::move(fontFolder)));
+    } else {
+        LOG_INFO("FontMonitor: %s is already tracked", path);
+    }
+}
+
+void wslgd::FontMonitor::RemoveMonitorFolder(const char *path)
+{
+    std::string monitorPath(path);
+    m_fontMonitorFolders.erase(monitorPath);
+}
+
+void wslgd::FontMonitor::HandleFolderEvent(struct inotify_event *event)
+{
+    if (event->wd == m_wd) {
+        LOG_INFO("FontMonitor: font directroy change: %s/%s 0x%x",
+               c_fontMonitorRootPath, event->name, event->mask);
+        if (event->mask & (IN_CREATE|IN_MOVED_TO)) {
+            std::string fullPath(c_fontMonitorRootPath);
+            fullPath += event->name;
+            AddMonitorFolder(fullPath.c_str());
+        } else if (event->mask & (IN_DELETE|IN_MOVED_FROM)) {
+            std::string fullPath(c_fontMonitorRootPath);
+            fullPath += event->name;
+            RemoveMonitorFolder(fullPath.c_str());
+        }
+    }
+}
+
+void wslgd::FontMonitor::HandleFontsDirEvent(struct inotify_event *event)
+{
+    std::map<std::string, std::unique_ptr<FontFolder>>::iterator it;
+    for (it = m_fontMonitorFolders.begin(); it != m_fontMonitorFolders.end(); it++) {
+        if (event->wd == it->second->GetWd()) {
+            if (event->mask & (IN_CREATE|IN_MOVED_TO)) {
+                std::string fonts_dir(it->second->GetPath());
+                fonts_dir += "/";
+                fonts_dir += event->name;
+                if (access(fonts_dir.c_str(), R_OK) == 0) {
+                    sleep(2); // TODO:
+                    it->second->ModifyX11FontPath(true);
+                } else {
+                    LOG_ERROR("FontMonitor: %s is not accessible but reported by watch", fonts_dir.c_str());
+                }
+            } else if (event->mask & (IN_DELETE|IN_MOVED_FROM)) {
+                it->second->ModifyX11FontPath(false);
+            }
+            break;
+        }
+    }
+}
+        
+void* wslgd::FontMonitor::FontMonitorThread(void *context)
+{
+    FontMonitor *This = reinterpret_cast<FontMonitor*>(context);
+    struct inotify_event *event;
+    int len, cur;
+    char buf[10 * (sizeof *event + 256)];
+
+    LOG_INFO("FontMonitor: monitoring thread started.");
+
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+
+    // Dump currently tracking folders.
+    This->DumpMonitorFolders();
+
+    // Start listening folder add/remove.
+    for (;;) {
+        len = read(This->GetFd(), buf, sizeof buf);
+        cur = 0;
+        while (cur < len) {
+            event = (struct inotify_event *)&buf[cur];
+            if (event->len) {
+                if (event->mask & IN_ISDIR) {
+                    // A directory is added or removed.
+                    This->HandleFolderEvent(event);
+                } else if (strcmp(event->name, c_fontsdir) == 0) {
+                    // A fonts.dir is added or removed.
+                    This->HandleFontsDirEvent(event);
+                }
+            }
+            cur += (sizeof *event + event->len);
+        }
+    }
+    // never hit here.
+    assert(true);
+
+    return 0;
+}
+
+int wslgd::FontMonitor::Start()
+{
+    bool succeeded = false;
+
+    assert(m_fontMonitorFolders.empty());
+    assert(!m_fontMonitorThread);
+    assert(m_fd == -1);
+    assert(m_wd == -1);
+
+    try {
+        // xset must be installed.
+        THROW_LAST_ERROR_IF(access(c_xset, X_OK) < 0);
+
+        // mount folder must be exists.
+        THROW_LAST_ERROR_IF_FALSE(std::filesystem::exists(c_fontMonitorRootPath));
+
+        // Start monitoring on root font folder.
+        THROW_LAST_ERROR_IF((m_fd = inotify_init()) < 0);
+        THROW_LAST_ERROR_IF((m_wd = inotify_add_watch(m_fd, c_fontMonitorRootPath, IN_CREATE|IN_DELETE|IN_MOVED_TO|IN_MOVED_FROM)) < 0);
+
+        // Add existing folders to track.
+        for (auto& dir_entry : std::filesystem::directory_iterator{c_fontMonitorRootPath}) {
+            if (dir_entry.is_directory())
+                AddMonitorFolder(dir_entry.path().c_str());
+        }
+
+        // Create font folder monitor thread.
+        THROW_LAST_ERROR_IF(pthread_create(&m_fontMonitorThread, NULL, FontMonitorThread, (void*)this) < 0);
+
+        succeeded = true;
+    }
+    CATCH_LOG();
+
+    if (!succeeded) {
+        Stop();
+        return -1;
+    }
+
+    return 0;
+}
+
+void wslgd::FontMonitor::Stop()
+{
+    // Stop font folder monitor thread.
+    if (m_fontMonitorThread) {
+        pthread_cancel(m_fontMonitorThread);
+        pthread_join(m_fontMonitorThread, NULL);
+        m_fontMonitorThread = 0;
+    }
+
+    if (m_wd >= 0) {
+        inotify_rm_watch(m_fd, m_wd);
+        m_wd = -1;
+    }
+
+    if (m_fd >= 0) {
+        close(m_fd);
+        m_fd = -1;
+    }
+
+    m_fontMonitorFolders.clear();
+
+    LOG_INFO("FontMonitor: monitoring stopped.");
+}

--- a/WSLGd/FontMonitor.cpp
+++ b/WSLGd/FontMonitor.cpp
@@ -43,29 +43,32 @@ wslgd::FontFolder::~FontFolder()
     }
 }
 
-void wslgd::FontFolder::ModifyX11FontPath(bool toAdd)
+void wslgd::FontFolder::ModifyX11FontPath(bool isAdd)
 {
-    int sys_ret;
     try {
-        /* update X server font path, add or remove. */
-        {
+        int sys_ret = -1;
+
+        if (m_isPathAdded != isAdd) {
+            /* update X server font path, add or remove. */
             std::string cmd(c_xset);
-            if (toAdd)
-               cmd += " +fp ";
+            if (isAdd)
+                cmd += " +fp ";
             else
-               cmd += " -fp ";
+                cmd += " -fp ";
             cmd += m_path;
             sys_ret = system(cmd.c_str());
             LOG_INFO("FontMonitor: execuate %s, returns 0x%x", cmd.c_str(), sys_ret);
         }
-        /* let X server reread font database */
-        {
+
+        if (sys_ret == 0) {
+            m_isPathAdded = isAdd;
+
+            /* let X server reread font database */
             std::string cmd(c_xset);
             cmd += " fp rehash";
             sys_ret = system(cmd.c_str());
             LOG_INFO("FontMonitor: execuate %s, returns 0x%x", cmd.c_str(), sys_ret);
         }
-        m_isPathAdded = toAdd;
     }
     CATCH_LOG();
 }

--- a/WSLGd/FontMonitor.cpp
+++ b/WSLGd/FontMonitor.cpp
@@ -73,6 +73,7 @@ void wslgd::FontFolder::ModifyX11FontPath(bool isAdd)
                 m_isPathAdded = isAdd;
 
                 /* let X server reread font database */
+                sleep(2); /* workaround for optional fonts.alias, wait 2 sec to run rehash */
                 std::string cmd(c_xset);
                 cmd += " fp rehash";
                 ExecuteShellCommand(cmd.c_str());

--- a/WSLGd/FontMonitor.h
+++ b/WSLGd/FontMonitor.h
@@ -48,11 +48,9 @@ namespace wslgd
         void HandleFontsDirEvent(struct inotify_event *event);
 
         int GetFd() const { return m_fd; }
-        int GetWd() const { return m_wd; }
 
     private:
         int m_fd = -1; /* from inotify_init() */
-        int m_wd = -1; /* from inotify_add_watch() for root folder */
         std::map<std::string, std::unique_ptr<FontFolder>> m_fontMonitorFolders{};
         pthread_t m_fontMonitorThread = 0;
     };

--- a/WSLGd/FontMonitor.h
+++ b/WSLGd/FontMonitor.h
@@ -13,14 +13,16 @@ namespace wslgd
 
         void ModifyX11FontPath(bool add);
 
-        int GetFd() const { return m_fd; }
+        static bool ExecuteShellCommand(const char *cmd);
+
+        int GetFd() const { return m_fd.get(); }
         int GetWd() const { return m_wd; }
 
         bool IsPathAdded() const { return m_isPathAdded; }
         const char *GetPath() const { return m_path.c_str(); }
 
     private:
-        int m_fd = -1; /* from FontMonitor's inotify_init() */
+        wil::unique_fd m_fd; /* from FontMonitor's inotify_init() */
         int m_wd = -1; /* from inotify_add_watch() for this folder */
         std::string m_path; /* this folder path */
         bool m_isPathAdded = false; /* whether font path is added to X11 font path */
@@ -47,10 +49,10 @@ namespace wslgd
         void HandleFolderEvent(struct inotify_event *event);
         void HandleFontsDirEvent(struct inotify_event *event);
 
-        int GetFd() const { return m_fd; }
+        int GetFd() const { return m_fd.get(); }
 
     private:
-        int m_fd = -1; /* from inotify_init() */
+        wil::unique_fd m_fd; /* from inotify_init() */
         std::map<std::string, std::unique_ptr<FontFolder>> m_fontMonitorFolders{};
         pthread_t m_fontMonitorThread = 0;
     };

--- a/WSLGd/FontMonitor.h
+++ b/WSLGd/FontMonitor.h
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+#pragma once
+#include "precomp.h"
+
+namespace wslgd
+{
+    class FontFolder
+    {
+    public:
+        FontFolder(int fd, const char *path);
+        ~FontFolder();
+
+        void ModifyX11FontPath(bool add);
+
+        int GetFd() const { return m_fd; }
+        int GetWd() const { return m_wd; }
+
+        bool IsPathAdded() const { return m_isPathAdded; }
+        const char *GetPath() const { return m_path.c_str(); }
+
+    private:
+        int m_fd = -1; /* from FontMonitor's inotify_init() */
+        int m_wd = -1; /* from inotify_add_watch() for this folder */
+        std::string m_path; /* this folder path */
+        bool m_isPathAdded = false; /* whether font path is added to X11 font path */
+    };
+
+    class FontMonitor
+    {
+    public:
+        FontMonitor();
+        ~FontMonitor() { Stop(); }
+
+        FontMonitor(const FontMonitor&) = delete;
+        void operator=(const FontMonitor&) = delete;
+
+        int Start();
+        void Stop();
+
+        static void* FontMonitorThread(void *context);
+
+        void AddMonitorFolder(const char *path);
+        void RemoveMonitorFolder(const char *path);
+        void DumpMonitorFolders();
+
+        void HandleFolderEvent(struct inotify_event *event);
+        void HandleFontsDirEvent(struct inotify_event *event);
+
+        int GetFd() const { return m_fd; }
+        int GetWd() const { return m_wd; }
+
+    private:
+        int m_fd = -1; /* from inotify_init() */
+        int m_wd = -1; /* from inotify_add_watch() for root folder */
+        std::map<std::string, std::unique_ptr<FontFolder>> m_fontMonitorFolders{};
+        pthread_t m_fontMonitorThread = 0;
+    };
+}

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -3,6 +3,7 @@
 #include "precomp.h"
 #include "common.h"
 #include "ProcessMonitor.h"
+#include "FontMonitor.h"
 
 #define CONFIG_FILE ".wslgconfig"
 #define SHARE_PATH "/mnt/wslg"
@@ -222,6 +223,9 @@ try {
     wslgd::ProcessMonitor monitor(c_userName);
     auto passwordEntry = monitor.GetUserInfo();
 
+    // Create a font folder monitor
+    wslgd::FontMonitor fontMonitor;
+
     // Make directories and ensure the correct permissions.
     std::filesystem::create_directories(c_dbusDir);
     THROW_LAST_ERROR_IF(chown(c_dbusDir, passwordEntry->pw_uid, passwordEntry->pw_gid) < 0);
@@ -401,6 +405,9 @@ try {
     // Wait weston to be ready before starting RDP client, pulseaudio server.
     WaitForReadyNotify(notifyFd.get());
     unlink(WESTON_NOTIFY_SOCKET);
+
+    // Start font monitoring.
+    fontMonitor.Start(); 
 
     // Launch the mstsc/msrdc client.
     std::string remote("/v:");

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -406,8 +406,9 @@ try {
     WaitForReadyNotify(notifyFd.get());
     unlink(WESTON_NOTIFY_SOCKET);
 
-    // Start font monitoring.
-    fontMonitor.Start(); 
+    // Start font monitoring if user distro's X11 fonts to be shared with system distro.
+    if (GetEnvBool("WSLG_USE_USER_DISTRO_XFONTS", true))
+        fontMonitor.Start(); 
 
     // Launch the mstsc/msrdc client.
     std::string remote("/v:");

--- a/WSLGd/meson.build
+++ b/WSLGd/meson.build
@@ -19,6 +19,7 @@ configure_file(output: 'config.h', configuration: config_h)
 executable('WSLGd',
            'main.cpp',
            'ProcessMonitor.cpp',
+           'FontMonitor.cpp',
            dependencies: dep_winpr,
            link_args: '-lcap',
            install : true)

--- a/WSLGd/precomp.h
+++ b/WSLGd/precomp.h
@@ -11,6 +11,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/inotify.h>
+#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -21,12 +23,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <pthread.h>
 #include <linux/vm_sockets.h>
 #include <filesystem>
 #include <map>
 #include <new>
-#include <vector>
-#include <map>
 #include <vector>
 #include "config.h"
 #include "lxwil.h"

--- a/config/local.conf
+++ b/config/local.conf
@@ -2,5 +2,6 @@
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
     <!-- Add fonts directory mapped from user distro -->
-    <dir>/mnt/wslg/fonts</dir>
+    <dir>/mnt/wslg/distro/usr/share/fonts</dir>
+    <dir>/mnt/wslg/distro/usr/local/share/fonts</dir>
 </fontconfig>

--- a/config/local.conf
+++ b/config/local.conf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-    <!-- Add Windows Font directory -->
-    <dir>/mnt/c/Windows/Fonts</dir>
+    <!-- Add fonts directory mapped from user distro -->
+    <dir>/mnt/wslg/fonts</dir>
 </fontconfig>


### PR DESCRIPTION
This monitor fonts folder mounted from user-distro, and add or remove X11 server font path at system-distro when X11 fonts are installed or removed at user-distro. With this change, this also removes font access to Windows's host side font (for now). This feature requires user-distro's /usr/share/fonts to be mapped at /mnt/wslg/fonts by @benhillis.

This will address the issue reported at https://github.com/microsoft/wslg/issues/310