### PR TITLE
Stop restarting processes if they exit more than 10 times in a minute

### DIFF
--- a/WSLGd/precomp.h
+++ b/WSLGd/precomp.h
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <algorithm>
 #include <linux/vm_sockets.h>
 #include <array>
 #include <filesystem>


### PR DESCRIPTION
This change adds logic to `wslgd::ProcessMonitor::Run` to keep track of how often processes exit and stops restarting processes that exit more than 10 times in 60 seconds.

Tested by running `pkill weston` 10 times in the system distro, stderr.txt shows:

```
<4>WSLGd: /usr/bin/sh -c /usr/bin/weston --backend=rdp-backend.so --modules=wslgd-notify.so --xwayland --log=/mnt/wslg/weston.log --socket=wayland-0 --shell=rdprail-shell.so --logger-scopes=log,rdp-backend,rdprail-shell exited more than 10 times in 60 seconds, not starting it again
```

This change should help mitigate https://github.com/microsoft/WSL/issues/6982 , since we've seen situations where wslg processes would crash and be restarted in a loop (although I don't think 100% of the high cpu usage issues are caused by wslg, I think some are) 