### PR TITLE
WSLGd: allow alternate rdp file via .wslgconfig

### DIFF
--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -32,5 +32,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <file src="package/WSLDVCPlugin_ARM64.pdb" target="build/native/bin/arm64/WSLDVCPlugin.pdb" />
 
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />
+    <file src="package/wslg_desktop.rdp" target="build/native/bin/wslg_desktop.rdp" />
   </files>
 </package>

--- a/Microsoft.WSLg.targets
+++ b/Microsoft.WSLg.targets
@@ -22,5 +22,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Link>wslg.rdp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)native\bin\wslg_desktop.rdp">
+      <Link>wslg_desktop.rdp</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -43,6 +43,9 @@ constexpr auto c_mstscFullPath = "/mnt/c/Windows/System32/mstsc.exe";
 constexpr auto c_westonShellOverrideEnv = "WSL2_WESTON_SHELL_OVERRIDE";
 constexpr auto c_westonRdprailShell = "rdprail-shell";
 
+constexpr auto c_rdpFileOverrideEnv = "WSL2_RDP_CONFIG_OVERRIDE";
+constexpr auto c_rdpFile = "wslg.rdp";
+
 void LogException(const char *message, const char *exceptionDescription) noexcept
 {
     fprintf(stderr, "<3>WSLGd: %s %s", message ? message : "Exception:", exceptionDescription);
@@ -446,7 +449,20 @@ try {
     else
         wslDvcPlugin = "/plugin:WSLDVC";
 
-    std::string rdpFilePath = wslInstallPath + "\\wslg.rdp";
+    std::filesystem::path rdpFilePath(wslInstallPath);
+    auto rdpFile = getenv(c_rdpFileOverrideEnv);
+    if (rdpFile) {
+        if (strstr(rdpFile, "..\\")) {
+            LOG_ERROR("RDP file must be placed under WSL install path (%s)", rdpFile);
+            rdpFile = nullptr;
+        }
+    }
+    if (rdpFile) {
+        rdpFilePath /= rdpFile;
+    } else {
+        rdpFilePath /= c_rdpFile;
+    }
+
     monitor.LaunchProcess(std::vector<std::string>{
         std::move(rdpClientExePath),
         std::move(remote),

--- a/package/wslg_desktop.rdp
+++ b/package/wslg_desktop.rdp
@@ -1,0 +1,5 @@
+audiocapturemode:i:2
+authentication level:i:0
+disableconnectionsharing:i:1
+enablecredsspsupport:i:0
+hvsocketenabled:i:1


### PR DESCRIPTION
allow alternate rdp file via .wslgconfig for experimental desktop remoting mode.