### PR TITLE
WSLg: Include missing array header

### DIFF
--- a/WSLGd/precomp.h
+++ b/WSLGd/precomp.h
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <linux/vm_sockets.h>
+#include <array>
 #include <filesystem>
 #include <map>
 #include <new>


### PR DESCRIPTION
This fixes the following error with gcc:

```
main.cpp: In function 'std::string TranslateWindowsPath(const char*)': main.cpp:80:27: error: aggregate 'std::array<char, 128> buffer' has incomplete type and cannot be defined
   80 |     std::array<char, 128> buffer;
      |                           ^~~~~~
```

std::array was added in 321cf1bcd4fd99112a0cde933816b0d9a4121e6b commit