### PR TITLE
system-distro: fix build error at mesa after mariner update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN echo "== Install Core dependencies ==" && \
         polkit-devel  \
         python3-devel \
         python3-mako  \
+        python3-markupsafe \
         sed \
         sqlite-devel \
         systemd-devel  \


### PR DESCRIPTION
fix build error (below) at mesa after mariner update.

```
[56/1041] Generating src/compiler/nir/nir_opt_algebraic.c with a custom command (wrapped by meson to capture output)
FAILED: src/compiler/nir/nir_opt_algebraic.c
/usr/bin/meson --internal exe --capture src/compiler/nir/nir_opt_algebraic.c -- /usr/bin/python3 ../src/compiler/nir/nir_opt_algebraic.py
--- stderr ---
Traceback (most recent call last):
  File "/work/vendor/mesa/build/../src/compiler/nir/nir_opt_algebraic.py", line 30, in <module>
    import nir_algebraic
  File "/work/vendor/mesa/src/compiler/nir/nir_algebraic.py", line 32, in <module>
    import mako.template
  File "/usr/lib/python3.9/site-packages/mako/template.py", line 20, in <module>
    from mako import codegen
  File "/usr/lib/python3.9/site-packages/mako/codegen.py", line 16, in <module>
    from mako import filters
  File "/usr/lib/python3.9/site-packages/mako/filters.py", line 14, in <module>
    import markupsafe
ModuleNotFoundError: No module named 'markupsafe'
```