### PR TITLE
WSLGd: Raise the NOFILE limit

### DIFF
--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -314,6 +314,10 @@ try {
     limit.rlim_max = RLIM_INFINITY;
     THROW_LAST_ERROR_IF(setrlimit(RLIMIT_CORE, &limit) < 0);
 
+    THROW_LAST_ERROR_IF(getrlimit(RLIMIT_NOFILE, &limit) < 0);
+    limit.rlim_cur = limit.rlim_max;
+    THROW_LAST_ERROR_IF(setrlimit(RLIMIT_NOFILE, &limit) < 0);
+
     // create folder to store core files.
     std::filesystem::create_directories(c_coreDir);
     THROW_LAST_ERROR_IF(chmod(c_coreDir, 0777) < 0);


### PR DESCRIPTION
XWayland uses many file descriptors. Bump the soft limit to the max to avoid hitting it. Fixes #862

Similar to https://github.com/swaywm/sway/pull/6629 and https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2235