### PR TITLE
WSLGd: redirect FreeRDP log to a file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,10 @@ RUN echo "== System distro build type (no debug strip):" ${BUILDTYPE_NODEBUGSTRI
 ENV BUILDTYPE_FREERDP=${BUILDTYPE_FREERDP:-RelWithDebInfo}
 RUN echo "== System distro build type (FreeRDP):" ${BUILDTYPE_FREERDP} " =="
 
+ENV WITH_DEBUG_FREERDP=${SYSTEMDISTRO_DEBUG_BUILD:+ON}
+ENV WITH_DEBUG_FREERDP=${WITH_DEBUG_FREERDP:-OFF}
+RUN echo "== System distro build type (FreeRDP Debug Options):" ${WITH_DEBUG_FREERDP} " =="
+
 ENV DESTDIR=/work/build
 ENV PREFIX=/usr
 ENV PKG_CONFIG_PATH=${DESTDIR}${PREFIX}/lib/pkgconfig:${DESTDIR}${PREFIX}/lib/${WSLG_ARCH}-linux-gnu/pkgconfig:${DESTDIR}${PREFIX}/share/pkgconfig
@@ -202,6 +206,7 @@ RUN cmake -G Ninja \
         -DCMAKE_INSTALL_PREFIX=${PREFIX} \
         -DCMAKE_INSTALL_LIBDIR=${PREFIX}/lib \
         -DCMAKE_BUILD_TYPE=${BUILDTYPE_FREERDP} \
+        -DWITH_DEBUG_ALL=${WITH_DEBUG_FREERDP} \
         -DWITH_ICU=ON \
         -DWITH_SERVER=ON \
         -DWITH_CHANNEL_GFXREDIR=ON \

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -411,7 +411,10 @@ try {
             std::vector<std::string>{
                 std::move(socketEnvString),
                 "WSLGD_NOTIFY_SOCKET=" WESTON_NOTIFY_SOCKET,
-                "WESTON_DISABLE_ABSTRACT_FD=1"
+                "WESTON_DISABLE_ABSTRACT_FD=1",
+                "WLOG_APPENDER=file",
+                "WLOG_FILEAPPENDER_OUTPUT_FILE_NAME=wlog.log",
+                "WLOG_FILEAPPENDER_OUTPUT_FILE_PATH=" SHARE_PATH
             }
         );
 


### PR DESCRIPTION
This redirects the logging from FreeRDP to a file at /mnt/wslg/wlog.log, also enable FreeRDP debugging when building system-distro with debug option enabled.