### PR TITLE
WSLGd: fix relaunch weston with env

### DIFF
--- a/WSLGd/ProcessMonitor.cpp
+++ b/WSLGd/ProcessMonitor.cpp
@@ -108,7 +108,7 @@ int wslgd::ProcessMonitor::Run() try {
                     LOG_ERROR("pid %d return unknown status %d, %s", pid, status, cmd.c_str());
                 }
 
-                LaunchProcess(std::move(found->second.argv), std::move(found->second.capabilities));
+                LaunchProcess(std::move(found->second.argv), std::move(found->second.capabilities), std::move(found->second.env));
             }
 
             m_children.erase(found);


### PR DESCRIPTION
fix to add private env when relaunching child process at process monitor.