### PR TITLE
Update Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ WSLg strives to make Linux GUI applications feel native and natural to use on Wi
 - It is recommended to run WSLg on a system with virtual GPU (vGPU) enabled for WSL so that you can benefit from hardware accelerated OpenGL rendering. You can find preview drivers supporting WSL from each of our partners below.
 
    - [AMD GPU driver for WSL](https://community.amd.com/community/radeon-pro-graphics/blog/2020/06/17/announcing-amd-support-for-gpu-accelerated-machine-learning-training-on-windows-10)
-   - [Intel GPU driver for WSL](https://downloadcenter.intel.com/download/30579/Intel-Graphics-Windows-DCH-Drivers)
+   - [Intel GPU driver for WSL](https://www.intel.com/content/www/us/en/download/19344/intel-graphics-windows-dch-drivers)
 
    - [NVIDIA GPU driver for WSL](https://developer.nvidia.com/cuda/wsl)
      


### PR DESCRIPTION
The link to the Intel GPU Driver for WSL is outdated (driver to up to 11th gen integrated graphics). New link includes support for newer GPUs (up to 13th gen integrated and new Xe dedicated)