### PR TITLE
WSLGd: launch RDP client with 'init' explicitly

### DIFF
--- a/WSLGd/ProcessMonitor.cpp
+++ b/WSLGd/ProcessMonitor.cpp
@@ -26,21 +26,8 @@ int wslgd::ProcessMonitor::LaunchProcess(
     if (childPid == 0) try {
         // Construct a null-terminated argument array.
         std::vector<const char*> arguments;
-        if (argv[0].compare("/init") != 0) {
-            for (auto &arg : argv) {
-                arguments.push_back(arg.c_str());
-            }
-        } else {
-            for (int i = 0; i < argv.size(); i++) {
-                arguments.push_back(argv[i].c_str());
-                if (i == 1) {
-                    /* insert executable name without full path after 
-                       full path executable at arguments[2] */
-                    auto const pos = argv[i].find_last_of('/');
-                    const auto leaf = argv[i].substr(pos + 1);
-                    arguments.push_back(leaf.c_str());
-                }
-            }
+        for (auto &arg : argv) {
+            arguments.push_back(arg.c_str());
         }
 
         arguments.push_back(nullptr);

--- a/WSLGd/ProcessMonitor.cpp
+++ b/WSLGd/ProcessMonitor.cpp
@@ -26,8 +26,21 @@ int wslgd::ProcessMonitor::LaunchProcess(
     if (childPid == 0) try {
         // Construct a null-terminated argument array.
         std::vector<const char*> arguments;
-        for (auto &arg : argv) {
-            arguments.push_back(arg.c_str());
+        if (argv[0].compare("/init") != 0) {
+            for (auto &arg : argv) {
+                arguments.push_back(arg.c_str());
+            }
+        } else {
+            for (int i = 0; i < argv.size(); i++) {
+                arguments.push_back(argv[i].c_str());
+                if (i == 1) {
+                    /* insert executable name without full path after 
+                       full path executable at arguments[2] */
+                    auto const pos = argv[i].find_last_of('/');
+                    const auto leaf = argv[i].substr(pos + 1);
+                    arguments.push_back(leaf.c_str());
+                }
+            }
         }
 
         arguments.push_back(nullptr);

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -7,6 +7,7 @@
 
 #define CONFIG_FILE ".wslgconfig"
 #define MSRDC_EXE "msrdc.exe"
+#define MSTSC_EXE "mstsc.exe"
 #define GDBSERVER_PATH "/usr/bin/gdbserver"
 #define WESTON_NOTIFY_SOCKET SHARE_PATH "/weston-notify.sock"
 #define DEFAULT_ICON_PATH "/usr/share/icons"
@@ -39,7 +40,7 @@ constexpr auto c_installPathEnv = "WSL2_INSTALL_PATH";
 constexpr auto c_userProfileEnv = "WSL2_USER_PROFILE";
 constexpr auto c_systemDistroEnvSection = "system-distro-env";
 
-constexpr auto c_mstscFullPath = "/mnt/c/Windows/System32/mstsc.exe";
+constexpr auto c_windowsSystem32 = "/mnt/c/Windows/System32";
 
 constexpr auto c_westonShellOverrideEnv = "WSL2_WESTON_SHELL_OVERRIDE";
 constexpr auto c_westonRdprailShell = "rdprail-shell";
@@ -473,7 +474,11 @@ try {
         }
     }
     if (rdpClientExePath.empty()) {
-        rdpClientExePath = c_mstscFullPath;
+        rdpClientExePath = c_windowsSystem32;
+        rdpClientExePath /= MSTSC_EXE;
+        isUseMstsc = true;
+    } else {
+        isUseMstsc = false;
     }
 
     std::string wslDvcPlugin;
@@ -502,6 +507,7 @@ try {
     monitor.LaunchProcess(std::vector<std::string>{
         "/init",
         std::move(rdpClientExePath),
+        isUseMstsc ? MSTSC_EXE : MSRDC_EXE,
         std::move(remote),
         std::move(serviceId),
         "/silent",

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -476,9 +476,6 @@ try {
     if (rdpClientExePath.empty()) {
         rdpClientExePath = c_windowsSystem32;
         rdpClientExePath /= MSTSC_EXE;
-        isUseMstsc = true;
-    } else {
-        isUseMstsc = false;
     }
 
     std::string wslDvcPlugin;
@@ -507,7 +504,7 @@ try {
     monitor.LaunchProcess(std::vector<std::string>{
         "/init",
         std::move(rdpClientExePath),
-        isUseMstsc ? MSTSC_EXE : MSRDC_EXE,
+        basename(rdpClientExePath.c_str()),
         std::move(remote),
         std::move(serviceId),
         "/silent",

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -500,6 +500,7 @@ try {
     }
 
     monitor.LaunchProcess(std::vector<std::string>{
+        "/init",
         std::move(rdpClientExePath),
         std::move(remote),
         std::move(serviceId),


### PR DESCRIPTION
This change to launch Windows RDP client executable with 'init' explicitly to avoid conflict in binfmt, which is reported at https://github.com/microsoft/WSL/issues/9257#issuecomment-1345550170.