### PR TITLE
Add libacl to runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -316,6 +316,7 @@ RUN echo "== Install Core/UI Runtime Dependencies ==" && \
             dhcp-client \
             e2fsprogs \
             freefont \
+            libacl \
             libinput \
             libjpeg-turbo \
             libltdl \


### PR DESCRIPTION
This change adds libacl to the runtime dependencies of the system distro vhd. We are planning on using this functionality in an upcoming WSL feature.