### PR TITLE
Revert "Add libacl to runtime dependencies"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -316,7 +316,6 @@ RUN echo "== Install Core/UI Runtime Dependencies ==" && \
             dhcp-client \
             e2fsprogs \
             freefont \
-            libacl \
             libinput \
             libjpeg-turbo \
             libltdl \


### PR DESCRIPTION
Turns out we don't need this.

Reverts microsoft/wslg#984