### PR TITLE
WSLGd: load keymap settings from .wslgconfig into weston.ini

### DIFF
--- a/WSLGd/precomp.h
+++ b/WSLGd/precomp.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <new>
 #include <vector>
+#include <algorithm>
 #include "config.h"
 #include "lxwil.h"
 #if HAVE_WINPR


### PR DESCRIPTION
Allow user to customize weston settings by  providing a `.weston.ini` file in User Profile directory.

The idea is to give advanced users an easy way to configure a keymap to fallback to if weston rdp backend logic fails to find a mapping between current keyboard layout and XKB ones. See https://github.com/microsoft/weston-mirror/pull/144 for further details.