### PR TITLE
WSLg: support SVG format icon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN echo "== Install Core dependencies ==" && \
         libltdl  \
         libltdl-devel  \
         libpng-devel  \
+        librsvg2-devel \
         libtiff  \
         libtiff-devel  \
         libusb  \
@@ -320,6 +321,7 @@ RUN echo "== Install Core/UI Runtime Dependencies ==" && \
             libjpeg-turbo \
             libltdl \
             libpng \
+            librsvg2 \
             libsndfile \
             libwayland-client \
             libwayland-server \


### PR DESCRIPTION
This PR enable SVG format icon can be used by WSLg to address issue reported at https://github.com/microsoft/wslg/issues/70. This PR requires https://github.com/microsoft/weston-mirror/pull/145 to be completed first.