### PR TITLE
WSLg: Update CBL-Mariner base image to 2.0.20230630

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Create a builder image with the compilers, etc. needed
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20230107 AS build-env
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20230630 AS build-env
 
 # Install all the required packages for building. This list is probably
 # longer than necessary.
@@ -305,7 +305,7 @@ RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
 
 ## Create the distro image with just what's needed at runtime
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20230107 AS runtime
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20230630 AS runtime
 
 RUN echo "== Install Core/UI Runtime Dependencies ==" && \
     tdnf    install -y \


### PR DESCRIPTION
Update CBL-Mariner base image to [2.0.20230630](https://github.com/microsoft/CBL-Mariner/releases/tag/2.0.20230630-2.0).