### PR TITLE
Added DirectX headers step

### DIFF
--- a/config/BUILD.md
+++ b/config/BUILD.md
@@ -20,12 +20,16 @@ For self-hosting WSLG check use this instructions https://github.com/microsoft/w
     git clone https://github.com/microsoft/pulseaudio-mirror.git vendor/pulseaudio -b working
     ```
 
-2. Download the mesa source code.
+2. Download the mesa and directx headers code.
 
     ```
     wget https://cblmarinerstorage.blob.core.windows.net/sources/core/mesa-21.0.0.tar.xz
     tar -xf mesa-21.0.0.tar.xz -C vendor
     mv vendor/mesa-21.0.0 vendor/mesa
+
+    wget https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.608.0.tar.gz
+    tar -xvf v1.608.0.tar.gz -C vendor
+    mv vendor/DirectX-Headers-1.608.0 vendor/DirectX-Headers-1.0
     ```
 
 3. Create the VHD:


### PR DESCRIPTION
The step about copying the DirectX headers was missing from this howto.

Used the step in the Azure pipeline file as the source and to avoid renumbering everything, I added the step to the existing `mesa` step.

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com