### PR TITLE
Remove logic to build and package .img disk images

### DIFF
--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -20,12 +20,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </metadata>
   <files>
     <file src="Microsoft.WSLg.targets" target="build/Microsoft.WSLg.targets" />
-    <file src="package/system_x64.img" target="build/native/bin/x64/system.img" />
     <file src="package/system_x64.vhd" target="build/native/bin/x64/system.vhd" />
     <file src="package/system-debuginfo_x64.tar.gz" target="build/native/bin/x64/system-debuginfo.tar.gz" />
     <file src="package/WSLDVCPlugin_x64.dll" target="build/native/bin/x64/WSLDVCPlugin.dll" />
     <file src="package/WSLDVCPlugin_x64.pdb" target="build/native/bin/x64/WSLDVCPlugin.pdb" />
-    <file src="package/system_ARM64.img" target="build/native/bin/arm64/system.img" />
     <file src="package/system_ARM64.vhd" target="build/native/bin/arm64/system.vhd" />
     <file src="package/system-debuginfo_ARM64.tar.gz" target="build/native/bin/arm64/system-debuginfo.tar.gz" />
     <file src="package/WSLDVCPlugin_ARM64.dll" target="build/native/bin/arm64/WSLDVCPlugin.dll" />

--- a/Microsoft.WSLg.targets
+++ b/Microsoft.WSLg.targets
@@ -6,10 +6,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)native\bin\$(Platform)\system.img">
-      <Link>system.img</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Include="$(MSBuildThisFileDirectory)native\bin\$(Platform)\system.vhd">
       <Link>system.vhd</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,21 +89,6 @@ stages:
           artifact: 'system_x64.vhd'
           publishLocation: 'pipeline'
 
-      - task: Go@0
-        inputs:
-          command: 'custom'
-          customCommand: 'run'
-          arguments: 'tar2ext4.go -i $(Agent.BuildDirectory)/system_x64.tar -o $(Agent.BuildDirectory)/system_x64.img'
-          workingDirectory: 'hcsshim/cmd/tar2ext4'
-        displayName: 'Create system_x64.img'
-
-      - task: PublishPipelineArtifact@1
-        displayName: 'Publish system_x64.img artifact'
-        inputs:
-          targetPath: $(Agent.BuildDirectory)/system_x64.img
-          artifact: 'system_x64.img'
-          publishLocation: 'pipeline'
-
       - task: PublishPipelineArtifact@1
         displayName: 'Publish system-debuginfo_x64.tar.gz artifact'
         inputs:
@@ -234,22 +219,6 @@ stages:
           artifact: 'system_arm64.vhd'
           publishLocation: 'pipeline'
 
-      - task: Go@0
-        inputs:
-          command: 'custom'
-          customCommand: 'run'
-          arguments: 'tar2ext4.go -i $(Agent.BuildDirectory)/system_arm64.tar -o $(Agent.BuildDirectory)/system_arm64.img'
-          workingDirectory: 'hcsshim/cmd/tar2ext4'
-        displayName: 'Create system_arm64.img'
-
-      - task: PublishPipelineArtifact@1
-        displayName: 'Publish system_arm64.img artifact'
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-        inputs:
-          targetPath: $(Agent.BuildDirectory)/system_arm64.img
-          artifact: 'system_arm64.img'
-          publishLocation: 'pipeline'
-
       - script: mkdir ./dev &&
                 ~/.docker/cli-plugins/docker-buildx build -f ./wslg/Dockerfile
                 --output type=tar,dest=./dev/dev_build.tar 
@@ -340,13 +309,6 @@ stages:
           targetPath: 'package/'
 
       - task: DownloadPipelineArtifact@2
-        displayName: 'Download system_x64.img'
-        inputs:
-          buildType: 'current'
-          artifactName: 'system_x64.img'
-          targetPath: 'package/'
-
-      - task: DownloadPipelineArtifact@2
         displayName: 'Download system-debuginfo_x64.tar.gz'
         inputs:
           buildType: 'current'
@@ -372,13 +334,6 @@ stages:
         inputs:
           buildType: 'current'
           artifactName: 'system_arm64.vhd'
-          targetPath: 'package/'
-
-      - task: DownloadPipelineArtifact@2
-        displayName: 'Download system_arm64.img'
-        inputs:
-          buildType: 'current'
-          artifactName: 'system_arm64.img'
           targetPath: 'package/'
 
       - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
This change removes the logic to build and package .img disk images since WSL doesn't use them and it makes the nuget package twice as big 