### PR TITLE
WSLg: update Mariner to 20231130 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Create a builder image with the compilers, etc. needed
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20231106 AS build-env
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20231130 AS build-env
 
 # Install all the required packages for building. This list is probably
 # longer than necessary.
@@ -129,6 +129,7 @@ ARG FREERDP_VERSION=2
 
 WORKDIR /work
 RUN echo "WSLg (" ${WSLG_ARCH} "):" ${WSLG_VERSION} > /work/versions.txt
+RUN echo "Built at:" `date --utc` >> /work/versions.txt
 
 RUN echo "Mariner:" `cat /etc/os-release | head -2 | tail -1` >> /work/versions.txt
 
@@ -305,7 +306,7 @@ RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
 
 ## Create the distro image with just what's needed at runtime
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20231106 AS runtime
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20231130 AS runtime
 
 RUN echo "== Install Core/UI Runtime Dependencies ==" && \
     tdnf    install -y \


### PR DESCRIPTION
This PR updates Mariner core image to 20231130 release, this also includes to add build date in versions.txt.