### PR TITLE
WSLg: Update Mariner to 2.0.20240112

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Create a builder image with the compilers, etc. needed
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20231130 AS build-env
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20240112 AS build-env
 
 # Install all the required packages for building. This list is probably
 # longer than necessary.
@@ -306,7 +306,7 @@ RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
 
 ## Create the distro image with just what's needed at runtime
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20231130 AS runtime
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20240112 AS runtime
 
 RUN echo "== Install Core/UI Runtime Dependencies ==" && \
     tdnf    install -y \


### PR DESCRIPTION
This PR to address https://github.com/microsoft/wslg/issues/1221.