### PR TITLE
Update wslgd to use the new wsl coredump infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
   id: dumps
   attributes:
     label: "WSL dumps:"
-    description: "Attach any dump files from `/mnt/wslg/dumps`, such as core.weston, if exists."
+    description: "Attach any dump files from `%tmp%\wsl-crashes`, such as core.weston, if exists. If running WSL < 2.3.13, the dump files can be found in `/mnt/wslg/dumps`"
   validations:
     required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
   id: dumps
   attributes:
     label: "WSL dumps:"
-    description: "Attach any dump files from `%tmp%\wsl-crashes`, such as core.weston, if exists. If running WSL < 2.3.13, the dump files can be found in `/mnt/wslg/dumps`"
+    description: "Attach any dump files from `%tmp%\wsl-crashes`, such as core.weston, if exists. If running an older version, the dump files can be found in `/mnt/wslg/dumps`"
   validations:
     required: false
 - type: textarea

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -346,37 +346,10 @@ try {
     std::string serviceIdEnvString("WSLG_SERVICE_ID=");
     serviceIdEnvString += ToServiceId(address.svm_port);
 
-    // "ulimits -c unlimited" for core dumps.
     struct rlimit limit;
-    limit.rlim_cur = RLIM_INFINITY;
-    limit.rlim_max = RLIM_INFINITY;
-    THROW_LAST_ERROR_IF(setrlimit(RLIMIT_CORE, &limit) < 0);
-
     THROW_LAST_ERROR_IF(getrlimit(RLIMIT_NOFILE, &limit) < 0);
     limit.rlim_cur = limit.rlim_max;
     THROW_LAST_ERROR_IF(setrlimit(RLIMIT_NOFILE, &limit) < 0);
-
-    // create folder to store core files.
-    std::filesystem::create_directories(c_coreDir);
-    THROW_LAST_ERROR_IF(chmod(c_coreDir, 0777) < 0);
-
-    // update core_pattern.
-    {
-        wil::unique_file corePatternFile(fopen(c_corePatternFile, "w"));
-        if (corePatternFile.get()) {
-            // combine folder path and core pattern.
-            std::string corePatternFullPath(c_coreDir);
-            corePatternFullPath += "/";
-            auto corePattern = getenv(c_corePatternEnv);
-            if (corePattern) {
-                corePatternFullPath += corePattern;
-            } else {
-                corePatternFullPath += c_corePatternDefault; // set to default core_pattern.
-            }
-            // write to core_pattern file.
-            THROW_LAST_ERROR_IF(fprintf(corePatternFile.get(), "%s", corePatternFullPath.c_str()) < 0);
-        }
-    }
 
     // Set shared memory mount point to env when available.
     if (!isSharedMemoryMounted ||

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -27,11 +27,6 @@ constexpr auto c_x11RuntimeDir = SHARE_PATH "/.X11-unix";
 constexpr auto c_xdgRuntimeDir = SHARE_PATH "/runtime-dir";
 constexpr auto c_stdErrLogFile = SHARE_PATH "/stderr.log";
 
-constexpr auto c_coreDir = SHARE_PATH "/dumps";
-constexpr auto c_corePatternDefault = "core.%e";
-constexpr auto c_corePatternFile = "/proc/sys/kernel/core_pattern";
-constexpr auto c_corePatternEnv = "WSL2_WSLG_CORE_PATTERN";
-
 constexpr auto c_sharedMemoryMountPoint = "/mnt/shared_memory";
 constexpr auto c_sharedMemoryMountPointEnv = "WSL2_SHARED_MEMORY_MOUNT_POINT";
 constexpr auto c_sharedMemoryObDirectoryPathEnv = "WSL2_SHARED_MEMORY_OB_DIRECTORY";


### PR DESCRIPTION
This change removes the logic to set the core pattern to /mnt/wslg/dumps and updates the issue template to direct users to the new coredump folder 