### PR TITLE
Escape backslash in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
   id: dumps
   attributes:
     label: "WSL dumps:"
-    description: "Attach any dump files from `%tmp%\wsl-crashes`, such as core.weston, if exists. If running an older version, the dump files can be found in `/mnt/wslg/dumps`"
+    description: "Attach any dump files from `%tmp%\\wsl-crashes`, such as core.weston, if exists. If running an older version, the dump files can be found in `/mnt/wslg/dumps`"
   validations:
     required: false
 - type: textarea


### PR DESCRIPTION
Bug reporting templates are not available because of this issue, so this should resolve the problem.