### PR TITLE
Fix permissions on runtime-dir

### DIFF
--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -294,7 +294,7 @@ try {
 
     std::filesystem::create_directories(c_xdgRuntimeDir);
     THROW_LAST_ERROR_IF(chown(c_xdgRuntimeDir, passwordEntry->pw_uid, passwordEntry->pw_gid) < 0);
-    THROW_LAST_ERROR_IF(chmod(c_xdgRuntimeDir, 0777) < 0);
+    THROW_LAST_ERROR_IF(chmod(c_xdgRuntimeDir, 0700) < 0);
 
     // Attempt to mount the virtiofs share for shared memory.
     bool isSharedMemoryMounted = false; 


### PR DESCRIPTION
As the weston error message explicitly says:

"Unix access mode must be 0700 (current mode is 777)

Change permissions accordingly.

Fixes: #1327 