### PR TITLE
WSLDVCPlugin: fix ReadSTRING null termination

### DIFF
--- a/WSLDVCPlugin/rdpapplist.h
+++ b/WSLDVCPlugin/rdpapplist.h
@@ -164,7 +164,7 @@ typedef struct _RDPAPPLIST_ASSOCIATE_WINDOW_ID
         goto Error_Read; \
     } if (o ## Length) { \
         ReadBYTES(o, p, o ## Length, r); \
-        o[o ## Length] = L'\0'; \
+        o[o ## Length / sizeof(WCHAR)] = L'\0'; \
     } else if (required) { \
         DebugPrint(LSTR(#o) L" is required\n"); \
         goto Error_Read; \


### PR DESCRIPTION
WSLDVCPlugin: fix ReadSTRING null termination - "Length" is in number of BYTES, thus has to be divided by sizeof(WCHAR).