### PR TITLE
Switch from cbl-mariner 2.0 to azure linux 3.0 and trim image size

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The system distro is essentially a Linux container packaged and distributed as a
 
 For folks who want to tinker with or customize their system distro, we give the ability to run a private version of the system distro. When running a private version of WSLg, Windows will load and run your private and ignore the Microsoft published one. If you update your WSL setup (`wsl --update`), the Microsoft published WSLg vhd will be updated, but you will continue to be running your private. You can switch between the Microsoft pulished WSLg system distro and a private one at any time although it does require restarting WSL (`wsl --shutdown`).
 
-The WSLg system distro is built using docker build. We essentially start from a [CBL-Mariner](https://github.com/microsoft/CBL-MarinerDemo) base image, install various packages, then build and install version of Weston, FreeRDP and PulseAudio from our mirror repo. This repository contains a Dockerfile and supporting tools to build the WSLg container and convert the container into an ext4 vhd that Windows will load as the system distro.
+The WSLg system distro is built using docker build. We essentially start from a [Azure Linux 3.0](https://github.com/microsoft/azurelinux) base image, install various packages, then build and install version of Weston, FreeRDP and PulseAudio from our mirror repo. This repository contains a Dockerfile and supporting tools to build the WSLg container and convert the container into an ext4 vhd that Windows will load as the system distro.
 
 ## Build instructions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ WORKDIR /work
 RUN echo "WSLg (" ${WSLG_ARCH} "):" ${WSLG_VERSION} > /work/versions.txt
 RUN echo "Built at:" `date --utc` >> /work/versions.txt
 
-RUN echo "Mariner:" `cat /etc/os-release | head -2 | tail -1` >> /work/versions.txt
+RUN echo "Azure Linux:" `cat /etc/os-release | head -2 | tail -1` >> /work/versions.txt
 
 #
 # Build runtime dependencies.
@@ -367,6 +367,8 @@ RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
         rpm -e --nodeps llvm && \
         # Remove password dictionary (not needed in WSLg) \
         rpm -e --nodeps cracklib-dicts && \
+        # Remove systemd-resolved (provides resolvconf, but we use dhcpcd's built-in resolv.conf management) \
+        rpm -e --nodeps systemd-resolved && \
         \
         echo "== Removing unnecessary files ==" && \
         # Remove unused Mesa driver \
@@ -377,7 +379,7 @@ RUN if [ -z "$SYSTEMDISTRO_DEBUG_BUILD" ] ; then \
         echo "== Install development aid packages ==" && \
         tdnf install -y \
              gdb \
-             mariner-repos-debug \
+             azurelinux-repos-debug \
              nano \
              vim \
              wayland-debuginfo \

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Users wanting to use different servers than the one provided by WSLg can change 
 guiApplications=false
 ```
 
-The system distro is based on the Microsoft [CBL-Mariner Linux](https://github.com/microsoft/CBL-Mariner). This is a minimal Linux environment, just enough to run the various pieces of WSLg. For details on how to build and deploy a private system distro please see our [build instructions](CONTRIBUTING.md).
+The system distro is based on the Microsoft [Azure Linux 3.0](https://github.com/microsoft/azurelinux). This is a minimal Linux environment, just enough to run the various pieces of WSLg. For details on how to build and deploy a private system distro please see our [build instructions](CONTRIBUTING.md).
 
 Every WSL 2 user distro is paired with its own instance of the system distro. The system distro runs partially isolated from the user distro to which it is paired, in its own NS/PID/UTS namespace but shares other namespaces such as IPC, to allow for shared memory optimization across the boundary. 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
 
       - script: wget https://azurelinuxsrcstorage.blob.core.windows.net/sources/core/mesa-23.1.0.tar.xz &&
                 tar -xvf mesa-23.1.0.tar.xz
-        displayName: 'Download Mesa from CBL Mariner'
+        displayName: 'Download Mesa from Azure Linux'
 
       - script: wget https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.608.0.tar.gz &&
                 tar -xvf v1.608.0.tar.gz
@@ -57,7 +57,7 @@ stages:
                 ./wslg 
                 --build-arg WSLG_VERSION=`gitversion /targetpath ./wslg /showvariable InformationalVersion`
                 --build-arg WSLG_ARCH=x86_64
-        displayName: 'Create System Distro Docker image Mariner-x64'
+        displayName: 'Create System Distro Docker image Azure Linux 3.0 x64'
 
       - script: docker export `docker create system-distro-x64` > $(Agent.BuildDirectory)/system_x64.tar
         displayName: 'Create system_x64.tar'
@@ -67,7 +67,7 @@ stages:
                 --build-arg WSLG_VERSION=`gitversion /targetpath ./wslg /showvariable InformationalVersion`
                 --build-arg WSLG_ARCH=x86_64
                 --target dev
-        displayName: 'Create System Distro Dev Docker image Mariner-x64'
+        displayName: 'Create System Distro Dev Docker image Azure Linux 3.0 x64'
 
       - script: docker cp `docker create system-distro-dev-x64 /bin/bash`:/work/debuginfo/system-debuginfo.tar.gz $(Agent.BuildDirectory)/system-debuginfo_x64.tar.gz
         displayName: 'Copy system-debuginfo_x64.tar.gz'
@@ -188,7 +188,7 @@ stages:
 
       - script: wget https://azurelinuxsrcstorage.blob.core.windows.net/sources/core/mesa-23.1.0.tar.xz &&
                 tar -xvf mesa-23.1.0.tar.xz
-        displayName: 'Download Mesa from CBL Mariner'
+        displayName: 'Download Mesa from Azure Linux'
 
       - script: wget https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.608.0.tar.gz &&
                 tar -xvf v1.608.0.tar.gz

--- a/config/BUILD.md
+++ b/config/BUILD.md
@@ -23,7 +23,7 @@ For self-hosting WSLG check use this instructions https://github.com/microsoft/w
 2. Download the mesa and directx headers code.
 
     ```
-    wget https://cblmarinerstorage.blob.core.windows.net/sources/core/mesa-23.1.0.tar.xz
+    wget https://azurelinuxsrcstorage.blob.core.windows.net/sources/core/mesa-23.1.0.tar.xz
     tar -xf mesa-23.1.0.tar.xz -C vendor
     mv vendor/mesa-23.1.0 vendor/mesa
 


### PR DESCRIPTION
Migrates WSLg from CBL-Mariner 2.0 to Azure Linux 3.0.

Also cleaned up the runtime image while I was at it - removed unnecessary packages and files that got pulled in but aren't actually needed. VHD size went from 961MB to 449MB with this tweaks.

Changes:
- Updated base images to `mcr.microsoft.com/azurelinux/base/core:3.0`
- Fixed package names: `xorg-x11-server-Xwayland-devel`, `dhcpcd` (this requires a small change to the WSL repo as well)
- Removed build tools (gcc, perl), python3, and llvm from runtime (only needed during build)
- Cleaned up devel packages incorrectly pulled by librsvg2 dependency bug
- Removed docs, man pages, and other runtime-unnecessary files

Tested by building the VHD and verifying size reduction.