### PR TITLE
Align Weston debuginfo paths with 14.0.2 metadata

### DIFF
--- a/debuginfo/weston.list
+++ b/debuginfo/weston.list
@@ -1,11 +1,11 @@
 usr/bin/weston
 usr/bin/weston-launch
 usr/bin/weston-screenshooter
-usr/lib/libweston-9.so.0.0.0
-usr/lib/libweston-desktop-9.so.0.0.0
-usr/lib/libweston-9/gl-renderer.so
-usr/lib/libweston-9/rdp-backend.so
-usr/lib/libweston-9/xwayland.so
+usr/lib/libweston-14.so.0.0.0
+usr/lib/libweston-desktop-14.so.0.0.0
+usr/lib/libweston-14/gl-renderer.so
+usr/lib/libweston-14/rdp-backend.so
+usr/lib/libweston-14/xwayland.so
 usr/lib/weston/libexec_weston.so.0.0.0
 usr/lib/weston/desktop-shell.so
 usr/lib/weston/rdprail-shell.so


### PR DESCRIPTION
- Fixes https://github.com/microsoft/wslg/issues/1349 .
- Fixes https://github.com/microsoft/wslg/issues/1345 .
- Align Weston debuginfo paths with 14.0.2 metadata. This is a follow-up operation to https://github.com/microsoft/weston-mirror/pull/159, which needs to be merged first.
- This should also alleviate the issue at https://github.com/zed-industries/zed/issues/47128 and https://github.com/microsoft/wslg/issues/1345 . zed hardcodes a lot of abstract system dependency checks.
- However, updating Weston will make some changes to the visuals. See https://github.com/qq1038765585/wslg_title_bar_beautify . 
- <img width="1344" height="149" alt="image" src="https://github.com/user-attachments/assets/7d206bb9-d3a5-4967-8b8f-f4d6dcb00219" />
- After merging this PR, wslg will support Dark mode. See https://github.com/qq1038765585/wslg_title_bar_beautify?tab=readme-ov-file#lightdark-switch . Of course, the changes at https://github.com/microsoft/weston-mirror/pull/129 and https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1154 are not discussed in the current PR.