### PR TITLE
Add NOTICE.txt, LICENSE, and license metadata to nuspec

### DIFF
--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -12,6 +12,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <owners>Microsoft, WSL Team</owners>
     <projectUrl>https://github.com/microsoft/wslg/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
     <description>WSLg support package.</description>
     <summary>Enabling the Windows Subsystem for Linux to include support for Wayland and X server related scenarios.</summary>
     <releaseNotes>ebad9c1</releaseNotes>
@@ -31,5 +32,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />
     <file src="package/wslg_desktop.rdp" target="build/native/bin/wslg_desktop.rdp" />
+
+    <file src="package/NOTICE.txt" target="NOTICE.txt" />
+    <file src="LICENSE" target="LICENSE.txt" />
   </files>
 </package>

--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -12,6 +12,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <projectUrl>https://github.com/microsoft/wslg</projectUrl>
     <repository type="git" url="https://github.com/microsoft/wslg.git" commit="$commit$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
     <description>WSLg system distribution and WSLDVCPlugin for the Windows Subsystem for Linux: Wayland, X11, audio (PulseAudio), and RemoteApp (RDP) support.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags>wsl wslg wayland weston x11 native</tags>
@@ -29,5 +30,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />
     <file src="package/wslg_desktop.rdp" target="build/native/bin/wslg_desktop.rdp" />
+
+    <file src="package/NOTICE.txt" target="NOTICE.txt" />
+    <file src="LICENSE" target="LICENSE.txt" />
   </files>
 </package>

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -32,7 +32,7 @@
         },        
         {
             "Component": { 
-                "Type": "mesa", 
+                "Type": "git", 
                 "Git": {
                     "RepositoryUrl": "https://github.com/mesa3d/mesa", 
                     "CommitHash": "731ea06758663a2de3a2bd1f12eb8809d4c136fd"
@@ -40,5 +40,15 @@
             },
             "DevelopmentDependency": false
         },
+        {
+            "Component": { 
+                "Type": "git", 
+                "Git": {
+                    "RepositoryUrl": "https://github.com/microsoft/DirectX-Headers", 
+                    "CommitHash": "cf123266ce6f1e9a6e700642edb6356bff1e3d55"
+                }
+            },
+            "DevelopmentDependency": false
+        }
     ]
 }


### PR DESCRIPTION
## Summary

OSS compliance updates for the NuGet package and Component Governance.

### NuGet package (Microsoft.WSLg.nuspec)
- Add **\<license type="expression">MIT</license>\** metadata
- Include **NOTICE.txt** (generated by \
otice@0\ pipeline task) in the package
- Include **LICENSE** in the package

### Component Governance (cgmanifest.json)
- Add **DirectX-Headers** v1.608.0
- Fix Mesa entry type from \mesa\ to \git\

### Related
Companion PR in \wslg-build\: [PR #15287628](https://microsoft.visualstudio.com/DxgkLinux/_git/wslg-build/pullrequest/15287628) — adds CG detection, SBOM generation, NOTICE.txt generation and verification to the build pipeline.