### PR TITLE
Add GitVersion.yml to override release/* branch defaults

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,17 @@
+# GitVersion config for WSLg.
+#
+# On release/* branches we ship hotfix / servicing builds on top of an
+# existing release tag (e.g. release/1.0.73 from tag v1.0.73). We do
+# NOT want gitversion's default GitFlow behavior of bumping Minor and
+# applying a 'beta' pre-release label.
+#
+# Instead, the version should stay at the source tag's Major.Minor.Patch
+# (e.g. 1.0.73), with BuildMetaData = commits since the tag. The
+# wslg-build pipeline derives the 4th component from BuildMetaData
+# (e.g. 1.0.73 + 1 commit -> 1.0.73.1).
+branches:
+  release:
+    increment: None
+    label: ''
+    prevent-increment:
+      when-current-commit-tagged: true


### PR DESCRIPTION
## Summary

Add an explicit `GitVersion.yml` so that any future `release/X.Y.Z` servicing branch (cut from a `vX.Y.Z` tag) computes its version as `Major.Minor.Patch` from the source tag, with `BuildMetaData` = commits past the tag, instead of gitversion's default GitFlow behavior of bumping Minor and applying a `beta` pre-release label.

## Why

The wslg-build pipeline renders `BuildMetaData` as a 4th component (e.g. `1.0.73 + 1 commit` -> `Microsoft.WSLg 1.0.73.1`, a stable NuGet release that orders above `1.0.73`). Without this override, a build off `release/1.0.73` would compute `1.1.0-beta.1+1` instead of `1.0.73.1` -- much higher than the next planned release on `main` (currently `1.0.77-Beta`), which would break upgrade ordering.

This was already added directly to `release/1.0.73` to unblock the WSL 2.7.x weston hotfix; landing it on `main` makes it the default for all future `release/*` branches. Pairs with the wslg-build pipeline parameterization in https://microsoft.visualstudio.com/DefaultCollection/DxgkLinux/_git/wslg-build/pullrequest/15598146.

## Verification

`main` and feature branches are unaffected (the override only touches the `release` branch block):

| Branch | Before | After |
|---|---|---|
| `main` (at `v1.0.76`) | `1.0.76` | `1.0.76` |
| `main` + 1 commit past tag | `1.0.77, BuildMeta=1` -> `1.0.77-Beta1` | `1.0.77, BuildMeta=1` -> `1.0.77-Beta1` |
| `release/1.0.73` from `v1.0.73` + 1 commit | `1.1.0-beta.1+1` (BAD) | `1.0.73, BuildMeta=1` -> `1.0.73.1` |

(All three verified locally with gitversion 6.3.0.)
