### PR TITLE
Add community triage infrastructure: CI lint, stale bot, CODEOWNERS, docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CODEOWNERS for microsoft/wslg
+#
+# Pull requests that touch the listed paths automatically request a review
+# from the listed owners. The catch-all entry at the top of the file applies
+# when no later rule matches.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customization/customizing-your-repository/about-code-owners
+
+* @benhillis
+
+# Build / packaging
+/Dockerfile                @benhillis
+/azure-pipelines.yml       @benhillis
+/devops/                   @benhillis
+/package/                  @benhillis
+/msi/                      @benhillis
+/Microsoft.WSLg.nuspec     @benhillis
+/Microsoft.WSLg.targets    @benhillis
+/build-and-export.sh       @benhillis
+
+# Source components
+/WSLGd/                    @benhillis
+/WSLDVCPlugin/             @benhillis
+/rdpapplist/               @benhillis
+
+# Docs / community
+/docs/                     @benhillis
+/README.md                 @benhillis
+/CONTRIBUTING.md           @benhillis
+/SECURITY.md               @benhillis
+/.github/                  @benhillis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,31 +1,11 @@
 # CODEOWNERS for microsoft/wslg
 #
-# Pull requests that touch the listed paths automatically request a review
-# from the listed owners. The catch-all entry at the top of the file applies
-# when no later rule matches.
+# Pull requests automatically request a review from the listed owners
+# when they touch matching paths. The catch-all entry below applies to
+# every path; per-path overrides can be added as the reviewer roster
+# grows beyond a single maintainer.
 #
 # See: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customization/customizing-your-repository/about-code-owners
 
 * @benhillis
 
-# Build / packaging
-/Dockerfile                @benhillis
-/azure-pipelines.yml       @benhillis
-/devops/                   @benhillis
-/package/                  @benhillis
-/msi/                      @benhillis
-/Microsoft.WSLg.nuspec     @benhillis
-/Microsoft.WSLg.targets    @benhillis
-/build-and-export.sh       @benhillis
-
-# Source components
-/WSLGd/                    @benhillis
-/WSLDVCPlugin/             @benhillis
-/rdpapplist/               @benhillis
-
-# Docs / community
-/docs/                     @benhillis
-/README.md                 @benhillis
-/CONTRIBUTING.md           @benhillis
-/SECURITY.md               @benhillis
-/.github/                  @benhillis

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,54 @@
+# Support
+
+WSLg (Windows Subsystem for Linux GUI) is an open source project maintained
+by Microsoft. This file describes the kinds of help available and where to
+take different kinds of requests.
+
+## Reporting bugs
+
+Open a [bug report](https://github.com/microsoft/wslg/issues/new?template=bug_report.yml).
+Please include:
+
+* The output of `wsl --version` from a Windows command prompt.
+* Your Windows build number (`[Environment]::OSVersion` in PowerShell).
+* Your distribution and version (`lsb_release -r` on Debian/Ubuntu).
+* WSLg logs from `\\wsl$\<Distro>\mnt\wslg` (`weston.log`, `stderr.log`,
+  and `pulseaudio.log` where applicable).
+* Crash dumps from `%TEMP%\wsl-crashes` if WSLg crashed.
+
+A current `wsl --version` is the single most useful piece of information.
+A large number of historic reports cannot be acted on because they were
+filed against versions of WSL or Windows that are no longer supported.
+
+## Feature requests
+
+Open a [feature request](https://github.com/microsoft/wslg/issues/new?template=feature_request.yml).
+Upvote (👍) the top comment on existing issues rather than commenting "+1";
+the maintainer team uses reaction counts as a prioritization signal.
+
+## Reporting WSL bugs (not WSLg)
+
+If the issue isn't specific to graphical applications, audio, clipboard,
+or window integration, please file it at
+[microsoft/WSL](https://github.com/microsoft/WSL/issues/new/choose) instead.
+
+## Security issues
+
+Please do **not** open public issues for security vulnerabilities. Follow
+the process in [SECURITY.md](../SECURITY.md).
+
+## Response expectations
+
+WSLg is maintained by a small team. We aim to:
+
+* Triage new issues within 30 days.
+* Respond to pull requests within 30 days.
+* Ship a release roughly every 1–3 months.
+
+Issues that go a year without activity may be closed by the stale bot.
+Reopen with current `wsl --version` output if the problem persists.
+
+## Commercial support
+
+WSLg ships with Windows. For commercial support of WSL itself, see
+[Microsoft support options](https://support.microsoft.com/).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -10,11 +10,13 @@ Open a [bug report](https://github.com/microsoft/wslg/issues/new?template=bug_re
 Please include:
 
 * The output of `wsl --version` from a Windows command prompt.
-* Your Windows build number (`[Environment]::OSVersion` in PowerShell).
+* Your Windows build number (`[Environment]::OSVersion.Version.Build` in
+  PowerShell, or `ver` in cmd).
 * Your distribution and version (`lsb_release -r` on Debian/Ubuntu).
 * WSLg logs from `\\wsl$\<Distro>\mnt\wslg` (`weston.log`, `stderr.log`,
   and `pulseaudio.log` where applicable).
-* Crash dumps from `%TEMP%\wsl-crashes` if WSLg crashed.
+* Crash dumps from `%tmp%\wsl-crashes` (or, on older WSL releases,
+  `/mnt/wslg/dumps`) if WSLg crashed.
 
 A current `wsl --version` is the single most useful piece of information.
 A large number of historic reports cannot be acted on because they were

--- a/.github/TRIAGE.md
+++ b/.github/TRIAGE.md
@@ -1,0 +1,96 @@
+# Issue triage guide
+
+This file documents how issues and pull requests are triaged in
+microsoft/wslg. It exists so that external contributors can understand
+why a label was applied and so that a new maintainer can pick up the
+queue without re-deriving the conventions.
+
+## Labels
+
+### Type
+
+| Label | Meaning |
+|---|---|
+| `bug` | Something doesn't work as designed. Applied automatically by the bug-report issue template. |
+| `enhancement` | A request for new behavior or a roadmap item. Applied automatically by the feature-request template. |
+| `documentation` | Docs-only change or docs-only gap. |
+| `question` | Support question rather than a defect; usually redirected to discussions. |
+| `duplicate` | Duplicate of another issue. Close with a comment that links the canonical issue. |
+| `invalid` | Not actionable as filed (missing information, off-topic, etc.). |
+| `wontfix` | Acknowledged but the team has decided not to take it. |
+
+### Area
+
+| Label | Meaning |
+|---|---|
+| `audio-redirection` | PulseAudio / PipeWire / ALSA audio path. |
+| `clipboard-integration` | Clipboard sync between Windows and Linux. |
+| `GPU` | DirectX/dxcore GPU passthrough, Mesa, dzn. |
+| `keyboard-layout` | Keyboard, IME, layout mapping. |
+| `rdp-client-connection` | mstsc / msrdc.exe client behavior. |
+| `server-connection` | Wayland/X server side connection issues. |
+| `start-menu-integration` | App shortcuts, icons, launchers. |
+| `window-management` | Sizing, snapping, focus, decorations. |
+| `Missing-Desktop-Dependencies` | User's distro is missing required packages. |
+| `Install-Issue` | Problem occurs during install/setup, not at runtime. |
+
+### Process
+
+| Label | Meaning |
+|---|---|
+| `Waiting User Info` | We've asked the author for more information. Auto-closed after 44 days of silence by the stale workflow. |
+| `fixinbound` | A fix has been committed internally and is on its way to a public release. |
+| `weston-upstream-bug` | Root cause is in upstream Weston; tracked there. |
+| `help wanted` | Maintainers welcome a community PR for this. Exempt from stale bot. |
+| `good first issue` | Suitable starting task for new contributors. Exempt from stale bot. |
+| `do-not-merge` | PR is held intentionally; do not merge even if green. |
+| `stale` | Applied by the stale workflow after a long period of inactivity. |
+| `hacktoberfest`, `hacktoberfest-accepted` | Used during Hacktoberfest only. |
+
+## Workflow
+
+1. **New issue arrives.** The issue templates auto-apply `bug` or
+   `enhancement`. Apply one or more *area* labels based on the
+   reported symptom.
+2. **Missing information.** If you can't act on the report, ask for
+   the missing pieces and apply `Waiting User Info`. The stale bot
+   will close it if the author doesn't respond within ~44 days.
+3. **Duplicate.** Apply `duplicate`, comment with a link to the
+   canonical issue, and close. Prefer keeping the oldest open issue
+   as the canonical one unless a newer one has materially better
+   information.
+4. **Upstream.** If the root cause is in Weston or another upstream
+   project, apply `weston-upstream-bug` (or open one) and link the
+   upstream tracker. These issues are exempt from the stale bot.
+5. **Internally fixed.** When a fix lands in an internal build but
+   hasn't shipped yet, apply `fixinbound`. Remove and close once the
+   public release is out.
+6. **Stale bot.** Issues with no activity for 365 days are marked
+   `stale` and closed 30 days later. Pull requests are marked stale
+   at 120 days and closed 30 days later. Draft PRs are exempt. See
+   [`.github/workflows/stale.yml`](workflows/stale.yml) for the full
+   exemption list.
+
+## Pull requests
+
+* Run the linters (`Lint` workflow) and the full Azure Pipelines
+  build (triggered internally) before merging.
+* Squash-merge unless the PR is split into logically separate commits
+  that should be preserved.
+* Use a release-branch PR (`user/<alias>/release-<version>`) to bump
+  the version and publish the next build.
+
+## Known cross-cutting issue clusters
+
+The same underlying defect generates many duplicate reports. When
+triaging, check whether the new report belongs to one of these
+clusters before opening or keeping a new tracking issue:
+
+* **Window focus loss / disappearance after network change or sleep**
+  — see #1092, #1098, #1108, #294, #1268.
+* **mstsc / msrdc.exe stealing focus or relaunching** — see #894,
+  #895, #655, #841.
+* **Fractional / HiDPI scaling** — see #23, #388, #584.
+* **Windows snap layouts and snapping** — see #22, #727.
+* **Ubuntu 24.04 regressions (slow startup, large cursor, Wayland
+  fallback)** — see #1244, #1250, #1290.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 
@@ -14,8 +13,8 @@ jobs:
     name: Hadolint (Dockerfile)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3.1.0
         with:
           dockerfile: Dockerfile
           failure-threshold: error
@@ -25,9 +24,9 @@ jobs:
     name: ShellCheck (*.sh)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
         env:
           SHELLCHECK_OPTS: -e SC2046 -e SC2086 -S warning
 
@@ -35,7 +34,7 @@ jobs:
     name: actionlint (workflows)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Run actionlint
         shell: bash
         env:
@@ -51,11 +50,16 @@ jobs:
   yamllint:
     name: yamllint
     runs-on: ubuntu-latest
+    # Non-blocking for now: the existing YAML in this repo has not been
+    # cleaned up against yamllint. Flip `continue-on-error` to false (or
+    # remove it) once existing YAML is clean.
+    continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Install yamllint
         run: pip install --user yamllint==1.35.1
-      - name: Lint YAML files (non-blocking)
+      - name: Lint YAML files
         run: |
           yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: {check-keys: false}}}" \
-            .github azure-pipelines.yml devops || true
+            .github azure-pipelines.yml devops
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,61 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: Hadolint (Dockerfile)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: error
+          ignore: DL3008,DL3009,DL3015,DL3041
+
+  shellcheck:
+    name: ShellCheck (*.sh)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        env:
+          SHELLCHECK_OPTS: -e SC2046 -e SC2086 -S warning
+
+  actionlint:
+    name: actionlint (workflows)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        shell: bash
+        env:
+          ACTIONLINT_VERSION: '1.7.7'
+          ACTIONLINT_SHA256: '023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757'
+        run: |
+          curl -fsSL -o actionlint.tgz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tgz" | sha256sum -c -
+          tar -xzf actionlint.tgz actionlint
+          ./actionlint -color
+
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yamllint
+        run: pip install --user yamllint==1.35.1
+      - name: Lint YAML files (non-blocking)
+        run: |
+          yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: {check-keys: false}}}" \
+            .github azure-pipelines.yml devops || true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generic stale (issues + PRs)
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9
         with:
           days-before-issue-stale: 365
           days-before-issue-close: 30
@@ -27,7 +27,10 @@ jobs:
           # `enhancement` is exempted because top-voted feature requests
           # often stay valid forever; the team prefers to close those
           # manually with `wontfix` rather than via the bot.
-          exempt-issue-labels: 'pinned,security,help wanted,good first issue,fixinbound,weston-upstream-bug,enhancement'
+          # `Waiting User Info` is exempted defensively so that if the
+          # waiting-user job is ever disabled or its label is renamed,
+          # those issues are not swept by the 365-day timer.
+          exempt-issue-labels: 'pinned,security,help wanted,good first issue,fixinbound,weston-upstream-bug,enhancement,Waiting User Info'
           exempt-pr-labels: 'pinned,security,do-not-merge'
           exempt-draft-pr: true
           stale-issue-message: >
@@ -57,13 +60,17 @@ jobs:
           ascending: true
 
       - name: Waiting-on-user stale
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9
         with:
           only-issue-labels: 'Waiting User Info'
           days-before-issue-stale: 30
           days-before-issue-close: 14
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          # Defense in depth: PR processing is disabled above, but set
+          # this anyway so that re-enabling PR processing in a future
+          # edit cannot accidentally start sweeping draft PRs.
+          exempt-draft-pr: true
           # Use a distinct label so this policy can't collide with the
           # generic policy (an issue marked `stale` by one job would
           # otherwise be eligible to be closed by the other).

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,87 @@
+name: Stale issues and PRs
+
+on:
+  schedule:
+    # Daily at 07:00 UTC
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark and close stale items
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generic stale (issues + PRs)
+        uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 365
+          days-before-issue-close: 30
+          days-before-pr-stale: 120
+          days-before-pr-close: 30
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          # `enhancement` is exempted because top-voted feature requests
+          # often stay valid forever; the team prefers to close those
+          # manually with `wontfix` rather than via the bot.
+          exempt-issue-labels: 'pinned,security,help wanted,good first issue,fixinbound,weston-upstream-bug,enhancement'
+          exempt-pr-labels: 'pinned,security,do-not-merge'
+          exempt-draft-pr: true
+          stale-issue-message: >
+            This issue has had no activity for a year. WSLg has a small
+            maintainer team and a large backlog, so we use inactivity as
+            a triage signal. If this is still reproducible on a current
+            WSL release, please add a comment with up-to-date
+            `wsl --version` output and any new reproduction details and
+            we'll keep it open. Otherwise it will be closed in 30 days.
+          close-issue-message: >
+            Closing as stale. If you can still reproduce this on a
+            current WSL release, please open a new issue (with current
+            `wsl --version` output and fresh logs) and reference this
+            one. Thank you.
+          stale-pr-message: >
+            This pull request has had no activity for 120 days. If
+            you'd like to land it, please rebase on `main` and address
+            any outstanding review feedback. Otherwise it will be
+            closed in 30 days.
+          close-pr-message: >
+            Closing as stale. Feel free to reopen with a rebase if
+            you'd like to pick the work back up.
+          # Keep ops low so the first runs don't flood subscriber
+          # inboxes with hundreds of notifications in a single day.
+          operations-per-run: 30
+          remove-stale-when-updated: true
+          ascending: true
+
+      - name: Waiting-on-user stale
+        uses: actions/stale@v9
+        with:
+          only-issue-labels: 'Waiting User Info'
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          # Use a distinct label so this policy can't collide with the
+          # generic policy (an issue marked `stale` by one job would
+          # otherwise be eligible to be closed by the other).
+          stale-issue-label: 'waiting-user-info-stale'
+          exempt-issue-labels: 'pinned,security,help wanted,good first issue,fixinbound,weston-upstream-bug'
+          # When the author responds, drop both the bot's stale marker
+          # and the `Waiting User Info` label so it routes back to the
+          # normal triage queue.
+          labels-to-remove-when-unstale: 'Waiting User Info'
+          stale-issue-message: >
+            We're waiting on additional information to triage this
+            issue. If we don't hear back in 14 days this will be
+            closed; please reopen with the requested details and
+            we'll take another look.
+          close-issue-message: >
+            Closing because we never received the requested
+            information. Please open a new issue (or comment here)
+            with the requested details and we'll reopen.
+          operations-per-run: 20
+          remove-stale-when-updated: true
+          ascending: true

--- a/docs/install-sample-gui-apps.sh
+++ b/docs/install-sample-gui-apps.sh
@@ -22,7 +22,7 @@ apt install x11-apps -y
 
 ## Google Chrome
 
-cd /tmp
+cd /tmp || exit
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 dpkg -i google-chrome-stable_current_amd64.deb 
 apt install --fix-broken -y
@@ -30,7 +30,7 @@ dpkg -i google-chrome-stable_current_amd64.deb
 
 ## Microsoft teams
 
-cd /tmp
+cd /tmp || exit
 curl -L -o "./teams.deb" "https://teams.microsoft.com/downloads/desktopurl?env=production&plat=linux&arch=x64&download=true&linuxArchiveType=deb"
 apt install ./teams.deb -y
 


### PR DESCRIPTION
## What

Adds the minimum viable triage infrastructure for `microsoft/wslg`:

- **CI lint workflow** — hadolint on `Dockerfile`, shellcheck on `*.sh`, actionlint (pinned to v1.7.7 + checksum) on workflows, non-blocking yamllint pass. Runs on PRs and pushes to `main`. Does not duplicate any work done by the production Azure Pipelines build.
- **Stale-bot workflow** — daily cron with **conservative** thresholds.
  - Issues: 365 d → `stale`, +30 d → close. Exempts `enhancement`, `help wanted`, `good first issue`, `fixinbound`, `weston-upstream-bug`, `pinned`, `security`.
  - PRs: 120 d → `stale`, +30 d → close. Drafts exempt.
  - `Waiting User Info` issues use a tighter 30 + 14 cycle and a **separate** `waiting-user-info-stale` label so the two policies cannot collide.
  - `operations-per-run` is intentionally low (30 / 20) so the first runs do not flood subscriber inboxes.
- **CODEOWNERS** — `@benhillis` as default reviewer on new PRs. Does not retroactively affect the 12 currently-open PRs.
- **`SUPPORT.md`** — response-time expectations, required info for bug reports, routing for non-WSLg issues.
- **`TRIAGE.md`** — documents the existing label taxonomy (which previously lived only in maintainer heads) and the cross-cutting issue clusters (network-change focus loss, mstsc focus stealing, HiDPI, Ubuntu 24.04 regressions) responsible for the bulk of duplicate reports.

## Why

The repo has ~669 open issues, 12 open PRs (oldest from 2022, 7 of them >100 days stale), and ~344 issues with no activity since 2024, but no automated triage support and no CODEOWNERS. Maintainers are shipping releases but cannot keep up with the issue queue. This PR is the cheapest possible step toward sustainability — it does not close any existing issue or PR, but it stops the bleeding going forward.

## Safety notes

- The stale workflow only runs on cron — merging this PR does **not** trigger an immediate sweep. The first sweep will run at the next 07:00 UTC tick.
- `operations-per-run` is deliberately small. If the first few runs look noisy, the workflow can be disabled from the Actions tab or the thresholds raised in a follow-up PR.
- Reaction counts are **not** used as activity, so popular feature requests are protected only by the `enhancement` exemption. If you want to be even more conservative, add `bug` to the exempt list and use the bot for PRs only.
- `CODEOWNERS` is intentionally minimal (everything routes to `@benhillis`). Expand it once other reviewers' aliases are known.

## Follow-up plan (separate PRs / issues)

1. Per-PR triage decisions on the existing 12 open PRs.
2. Labeling pass on the 88 unlabeled open issues.
3. Duplicate consolidation for the cross-cutting clusters listed in `TRIAGE.md`.
4. README "Project status & roadmap" section.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
