### PR TITLE
Drop vestigial -1.0 suffix from vendor/DirectX-Headers-1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The WSLg system distro is built using docker build. We essentially start from a 
     git clone https://github.com/microsoft/FreeRDP-mirror wslg/vendor/FreeRDP -b working
     git clone https://github.com/microsoft/weston-mirror wslg/vendor/weston -b working
     git clone https://github.com/microsoft/PulseAudio-mirror wslg/vendor/pulseaudio -b working
-    git clone https://github.com/microsoft/DirectX-Headers.git wslg/vendor/DirectX-Headers-1.0 -b v1.608.0
+    git clone https://github.com/microsoft/DirectX-Headers.git wslg/vendor/DirectX-Headers -b v1.608.0
     git clone https://gitlab.freedesktop.org/mesa/mesa.git wslg/vendor/mesa -b mesa-23.1.0
     ```
 
@@ -63,7 +63,7 @@ The WSLg system distro is built using docker build. We essentially start from a 
         --build-arg WSLG_VERSION="$(cd wslg && ./devops/get-nuget-version.sh -Beta)" \
         --build-arg WSLG_COMMIT="$(git -C wslg rev-parse HEAD)" \
         --build-arg WSLG_ARCH=x86_64 \
-        --build-arg DIRECTX_HEADERS_VERSION="$(git -C wslg/vendor/DirectX-Headers-1.0 rev-parse HEAD)" \
+        --build-arg DIRECTX_HEADERS_VERSION="$(git -C wslg/vendor/DirectX-Headers rev-parse HEAD)" \
         --build-arg FREERDP_COMMIT="$(git -C wslg/vendor/FreeRDP rev-parse HEAD)" \
         --build-arg MESA_VERSION="$(git -C wslg/vendor/mesa rev-parse HEAD)" \
         --build-arg PULSEAUDIO_COMMIT="$(git -C wslg/vendor/pulseaudio rev-parse HEAD)" \
@@ -107,7 +107,7 @@ To build a debug version of the system distro, append `--build-arg SYSTEMDISTRO_
         --build-arg WSLG_VERSION="$(cd wslg && ./devops/get-nuget-version.sh -Beta)" \
         --build-arg WSLG_COMMIT="$(git -C wslg rev-parse HEAD)" \
         --build-arg WSLG_ARCH=x86_64 \
-        --build-arg DIRECTX_HEADERS_VERSION="$(git -C wslg/vendor/DirectX-Headers-1.0 rev-parse HEAD)" \
+        --build-arg DIRECTX_HEADERS_VERSION="$(git -C wslg/vendor/DirectX-Headers rev-parse HEAD)" \
         --build-arg FREERDP_COMMIT="$(git -C wslg/vendor/FreeRDP rev-parse HEAD)" \
         --build-arg MESA_VERSION="$(git -C wslg/vendor/mesa rev-parse HEAD)" \
         --build-arg PULSEAUDIO_COMMIT="$(git -C wslg/vendor/pulseaudio rev-parse HEAD)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,8 +227,8 @@ COPY debuginfo /work/debuginfo
 RUN chmod +x /work/debuginfo/*.sh
 
 # Build DirectX-Headers
-COPY vendor/DirectX-Headers-1.0 /work/vendor/DirectX-Headers-1.0
-WORKDIR /work/vendor/DirectX-Headers-1.0
+COPY vendor/DirectX-Headers /work/vendor/DirectX-Headers
+WORKDIR /work/vendor/DirectX-Headers
 RUN /usr/bin/meson --prefix=${PREFIX} build \
         --buildtype=${BUILDTYPE_NODEBUGSTRIP} \
         -Dbuild-test=false && \

--- a/build-and-export.sh
+++ b/build-and-export.sh
@@ -25,7 +25,7 @@ WSLG_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "dev")
 # Vendor components: use rev-parse for the git-sourced ones, fall back
 # to the "dev" sentinel if a vendor dir was sourced from a tarball locally.
 vendor_commit() { git -C "$1" rev-parse HEAD 2>/dev/null || echo "dev"; }
-DIRECTX_HEADERS_VERSION=$(vendor_commit vendor/DirectX-Headers-1.0)
+DIRECTX_HEADERS_VERSION=$(vendor_commit vendor/DirectX-Headers)
 FREERDP_COMMIT=$(vendor_commit vendor/FreeRDP)
 MESA_VERSION=$(vendor_commit vendor/mesa)
 PULSEAUDIO_COMMIT=$(vendor_commit vendor/pulseaudio)

--- a/config/BUILD.md
+++ b/config/BUILD.md
@@ -29,7 +29,7 @@ For self-hosting WSLG check use this instructions https://github.com/microsoft/w
 
     wget https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.608.0.tar.gz
     tar -xvf v1.608.0.tar.gz -C vendor
-    mv vendor/DirectX-Headers-1.608.0 vendor/DirectX-Headers-1.0
+    mv vendor/DirectX-Headers-1.608.0 vendor/DirectX-Headers
     ```
 
 3. Create the VHD:


### PR DESCRIPTION
The `-1.0` suffix on `vendor/DirectX-Headers-1.0` is a vestige of a one-time experimental upgrade attempt. We only ship the one version of DirectX-Headers, so the suffix is dead version-skew baggage that's been confusing every new contributor opening the Dockerfile.

Rename to `vendor/DirectX-Headers` and update the 4 referencing files: Dockerfile (COPY + WORKDIR), build-and-export.sh (`vendor_commit` call), CONTRIBUTING.md (3 references in setup recipes), config/BUILD.md (mv command).

**Merge order matters** -- the companion bridge PR in wslg-build must merge first. The bridge materializes both the old and new vendor paths so wslg main + every `release/*` branch keeps building unchanged. After this PR lands and any maintained release branches have adopted the new name, a follow-up wslg-build PR can drop the bridge `cp -a` line.

Companion: https://github.com/microsoft/wslg-build/pull/new/user/benhillis/dxh-rename-bridge (link will redirect to the actual PR once filed)

Buddy: https://microsoft.visualstudio.com/DxgkLinux/_build/results?buildId=147259999 (paired wslg=this PR + wslg-build=`user/benhillis/dxh-rename-bridge`)