### PR TITLE
vendor: bump DirectX-Headers v1.619.1 and mesa 24.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The WSLg system distro is built using docker build. We essentially start from a 
     git clone https://github.com/microsoft/weston-mirror wslg/vendor/weston -b working
     git clone https://github.com/microsoft/PulseAudio-mirror wslg/vendor/pulseaudio -b working
     git clone https://github.com/microsoft/DirectX-Headers.git wslg/vendor/DirectX-Headers-1.0 -b v1.619.1
-    git clone https://gitlab.freedesktop.org/mesa/mesa.git wslg/vendor/mesa -b mesa-23.1.0
+    git clone https://gitlab.freedesktop.org/mesa/mesa.git wslg/vendor/mesa -b mesa-24.0.1
     ```
 
 3. Build the VHD. The easiest path is the helper script, which derives a version from `git describe`, captures each vendor's commit SHA, passes everything as `--build-arg`, runs `docker build`, exports the container, and converts to a VHD via `tar2ext4`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The WSLg system distro is built using docker build. We essentially start from a 
     git clone https://github.com/microsoft/FreeRDP-mirror wslg/vendor/FreeRDP -b working
     git clone https://github.com/microsoft/weston-mirror wslg/vendor/weston -b working
     git clone https://github.com/microsoft/PulseAudio-mirror wslg/vendor/pulseaudio -b working
-    git clone https://github.com/microsoft/DirectX-Headers.git wslg/vendor/DirectX-Headers-1.0 -b v1.608.0
+    git clone https://github.com/microsoft/DirectX-Headers.git wslg/vendor/DirectX-Headers-1.0 -b v1.619.1
     git clone https://gitlab.freedesktop.org/mesa/mesa.git wslg/vendor/mesa -b mesa-23.1.0
     ```
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -45,7 +45,7 @@
                 "Type": "git", 
                 "Git": {
                     "RepositoryUrl": "https://github.com/microsoft/DirectX-Headers.git", 
-                    "CommitHash": "cf123266ce6f1e9a6e700642edb6356bff1e3d55"
+                    "CommitHash": "9e393d6d8a3b30dcc6f2806ef604ec16a27b0d7e"
                 }
             },
             "DevelopmentDependency": false

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -35,7 +35,7 @@
                 "Type": "git", 
                 "Git": {
                     "RepositoryUrl": "https://gitlab.freedesktop.org/mesa/mesa.git", 
-                    "CommitHash": "be4f7fb656180ab55a50eff01f36672b0bf5f146"
+                    "CommitHash": "3e361635b8db45dbb4896ed3cc1bda54c138334b"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
Phase 1 of the vendor-source refresh: low-risk version bumps for the two components pinned by version-string in CI (DirectX-Headers and mesa). Companion change to wslg-build (the Azure DevOps pipeline) updates the same version defaults so CI consumes the new tarballs.

## Changes

- **CONTRIBUTING.md** — clone-tag instructions for new contributors bumped to the new versions:
  - DirectX-Headers: `v1.608.0` → `v1.619.1` (Nov 2022 → Mar 2026)
  - mesa: `mesa-23.1.0` → `mesa-24.0.1` (matches what Azure Linux 3.0 ships, per `microsoft/azurelinux` `SPECS/mesa/mesa.spec` on the `3.0` branch)
- **cgmanifest.json** — Component Governance manifest updated:
  - mesa `CommitHash` updated to the 24.0.1 tag commit `3e361635...`
  - New entry added for DirectX-Headers (`9e393d6d...`, v1.619.1) — this component previously had no cgmanifest entry

## Why

- DirectX-Headers v1.608.0 → v1.619.1: ~3.5 years of upstream improvements; headers-only, no CVE history; trivial bump.
- mesa 23.1.0 → 24.0.1: aligns with the mesa version Azure Linux 3.0 packages, so the WSLg-built mesa matches the host distro's mesa SBOM. Newer mesa versions aren't available from the `azurelinuxsrcstorage` blob CI downloads from (probed 24.0.2 through 25.2.x — all 404), so 24.0.1 is the realistic upper bound without re-plumbing CI's tarball source. Mesa's WSLg build flags (`-Dgallium-drivers=swrast,d3d12 -Dvulkan-drivers= -Dllvm=disabled`) are unchanged and continue to apply.

## Validation

- `./build-and-export.sh` completes all 88 Docker build steps with the new sources.
- Built image's `/etc/versions.txt` correctly carries the new commit SHAs.
- Mesa configures and installs both `swrast` and `d3d12` gallium DRI drivers as before.
- DirectX-Headers v1.619.1 builds cleanly via meson (no API churn affecting WSLg's consumers).

## Pairs with

Companion wslg-build PR `user/benhillis/phase1-vendor-bumps` updates the corresponding `mesaVersion` / `directxHeadersVersion` defaults in `devops/pipeline-shared.yml`, `wslg-github-buddy.yml`, and `wslg-github-release.yml` (plus the official-release enforcement check at `pipeline-shared.yml:146-147`).

## Not in scope

- FreeRDP, weston, pulseaudio versions — those are pulled from `microsoft/*-mirror` `working` branch tips at CI build time, not by this repo. See the upgrade plan / CVE summary for the follow-on phases.