### PR TITLE
Switch system distro build to FreeRDP 3.x (3.26.0) (Phase 3 / 3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ ARG MESA_VERSION="<unknown>"
 ARG PULSEAUDIO_COMMIT="<unknown>"
 ARG WESTON_COMMIT="<unknown>"
 ARG SYSTEMDISTRO_DEBUG_BUILD
-ARG FREERDP_VERSION=2
+ARG FREERDP_VERSION=3
 
 # Fail fast if any required --build-arg is missing or still holds a
 # placeholder value. We have to validate up-front because the values
@@ -265,9 +265,13 @@ RUN cmake -G Ninja \
         -DCMAKE_BUILD_TYPE=${BUILDTYPE_FREERDP} \
         -DWITH_DEBUG_ALL=${WITH_DEBUG_FREERDP} \
         -DWITH_ICU=ON \
+        -DWITH_FFMPEG=OFF \
+        -DWITH_DSP_FFMPEG=OFF \
+        -DWITH_VIDEO_FFMPEG=OFF \
+        -DWITH_SWSCALE=OFF \
+        -DWITH_KRB5=OFF \
         -DWITH_SERVER=ON \
-        -DWITH_CHANNEL_GFXREDIR=ON \
-        -DWITH_CHANNEL_RDPAPPLIST=ON \
+        -DCHANNEL_GFXREDIR=ON \
         -DWITH_CLIENT=OFF \
         -DWITH_CLIENT_COMMON=OFF \
         -DWITH_CLIENT_CHANNELS=OFF \

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -165,9 +165,13 @@ void SetupOptionalEnv()
     wIniFile* wslgConfigIniFile = IniFile_New();
     if (wslgConfigIniFile) {
         if (IniFile_ReadFile(wslgConfigIniFile, configFilePath.c_str()) > 0) {
+#if WINPR_VERSION_MAJOR >= 3
+            size_t numKeys = 0;
+#else
             int numKeys = 0;
+#endif
             char **keyNames = IniFile_GetSectionKeyNames(wslgConfigIniFile, c_systemDistroEnvSection, &numKeys);
-            for (int n = 0; keyNames && n < numKeys; n++) {
+            for (decltype(numKeys) n = 0; keyNames && n < numKeys; n++) {
                 const char *value = IniFile_GetKeyValueString(wslgConfigIniFile, c_systemDistroEnvSection, keyNames[n]);
                 if (value) {
                     setenv(keyNames[n], value, true);

--- a/WSLGd/precomp.h
+++ b/WSLGd/precomp.h
@@ -35,5 +35,6 @@
 #include "config.h"
 #include "lxwil.h"
 #if HAVE_WINPR
+#include "winpr/version.h"
 #include "winpr/ini.h"
 #endif // HAVE_WINPR

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -25,7 +25,7 @@
                 "Type": "git", 
                 "Git": {
                     "RepositoryUrl": "https://github.com/FreeRDP/FreeRDP", 
-                    "CommitHash": "39f56443f2dc50e0dcfa52d4f8f15008d5b8ed8e"
+                    "CommitHash": "3f6d7cb1f8973cc84c66b258a9a61c4e2b2f30a6"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
Switch the WSLg system distro build from the FreeRDP 2.4.0-era `microsoft/FreeRDP-mirror` fork to upstream **FreeRDP 3.x** (tag `3.26.0`).

This is **PR 1 of 3** in a coordinated migration. PR 2 (`microsoft/weston-mirror#163`) ports the weston rdp-backend to the FreeRDP 3.x server API. PR 3 (to be opened) will switch the ADO pipeline's FreeRDP repo resource from `microsoft/FreeRDP-mirror` to `FreeRDP/FreeRDP@3.26.0`. This PR alone is a no-op against the current pipeline.

## Why

The WSLg-pinned `microsoft/FreeRDP-mirror`'s `working` branch is built from a fork of FreeRDP 2.4.0 (Aug 2023), and the upstream 2.x line was declared EOL by the FreeRDP project. Only 3.x is supported. Tracking advisories from 2023-08 onward: 11 HIGH-severity CVEs in 2026 alone (e.g. CVE-2026-26955 OOB write, CVE-2026-31806 nsc heap overflow, CVE-2026-44420 cliprdr server heap overflow, CVE-2026-45700 planar bitmap decoder overflow). All are patched only in 3.x. Since WSLg runs the *server* side of RDP, the cliprdr / rdpgfx / cache PDU handlers in particular are reachable from a malicious or compromised mstsc client over TCP loopback or vsock.

## Diff

```
Dockerfile      | 10 +++++++---
WSLGd/main.cpp  |  6 +++++-
WSLGd/precomp.h |  1 +
3 files changed, 13 insertions(+), 4 deletions(-)
```

### `Dockerfile`

* `ARG FREERDP_VERSION=2` -> `=3` (also flips the debuginfo strip target from `FreeRDP2.list` to `FreeRDP3.list`).
* New cmake flags (each became REQUIRED-by-default in 3.x and is not desired for WSLg):
  - `-DWITH_FFMPEG=OFF`
  - `-DWITH_DSP_FFMPEG=OFF`
  - `-DWITH_VIDEO_FFMPEG=OFF`
  - `-DWITH_SWSCALE=OFF`
  - `-DWITH_KRB5=OFF`
* Removed `-DWITH_CHANNEL_GFXREDIR=ON` and `-DWITH_CHANNEL_RDPAPPLIST=ON`. `WITH_CHANNEL_GFXREDIR` is vestigial in upstream FreeRDP 3.x (the `cmakedefine` exists in `config.h.in` but no cmake logic ever sets it); `rdpapplist` is not a FreeRDP channel at all (the rdpapplist plugin is built standalone from `wslg/rdpapplist/`). Replaced with `-DCHANNEL_GFXREDIR=ON`, the correct upstream knob for enabling the gfxredir dynamic channel (default OFF).

### `WSLGd/main.cpp` + `WSLGd/precomp.h`

`IniFile_GetSectionKeyNames(..., size_t* count)` signature change in WinPR 3.x (was `int*`). Guarded with `#if WINPR_VERSION_MAJOR >= 3` so the file still compiles against WinPR 2.x. Added explicit `#include <winpr/version.h>` in `precomp.h`.

## Validation

End-to-end Docker build of the system distro succeeds against `FreeRDP/FreeRDP@3.26.0`. Verified in the built image:

* `/usr/lib/libfreerdp3.so.3.26.0`
* `/usr/lib/libwinpr3.so.3.26.0`
* `/usr/lib/libfreerdp-server3.so.3.26.0`, exports `gfxredir_server_context_{new,free}`, `audin_server_context_new`, `rdpsnd_server_context_new`, etc.
* `/usr/lib/rdpapplist/librdpapplist-server.so`, exports `rdpapplist_server_context_{new,free}`.
* `/usr/lib/libweston-9/rdp-backend.so` links against `libfreerdp3.so.3` / `libwinpr3.so.3` / `libfreerdp-server3.so.3`.

Runtime smoke test (xfreerdp loopback + Windows mstsc) is pending and will be performed before any of the three PRs is marked "Ready for review".

## Known limitations (tracked as follow-up)

* **RDP audio is disabled on FreeRDP 3.x.** The `audin_server_context` / `rdpsnd_server_context` APIs were rewritten in 3.x to a PDU-callback model; the wslg port is in flight in microsoft/weston-mirror#163 as a stub commit and a proper port will land before that PR is marked Ready.
* The file-cert TLS path (rdp.ini `cert-file`/`key-file`) currently errors out on FreeRDP 3.x. WSLg in production uses the session-generated TLS path via Hyper-V vsock, which is fully functional.
