### PR TITLE
Fix cgmanifest registration and package NOTICE/LICENSE metadata

### DIFF
--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -12,7 +12,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <projectUrl>https://github.com/microsoft/wslg</projectUrl>
     <repository type="git" url="https://github.com/microsoft/wslg.git" commit="$commit$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
+    <license type="file">LICENSE.txt</license>
     <description>WSLg system distribution and WSLDVCPlugin for the Windows Subsystem for Linux: Wayland, X11, audio (PulseAudio), and RemoteApp (RDP) support.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags>wsl wslg wayland weston x11 native</tags>

--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -12,6 +12,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <projectUrl>https://github.com/microsoft/wslg</projectUrl>
     <repository type="git" url="https://github.com/microsoft/wslg.git" commit="$commit$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
     <description>WSLg system distribution and WSLDVCPlugin for the Windows Subsystem for Linux: Wayland, X11, audio (PulseAudio), and RemoteApp (RDP) support.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags>wsl wslg wayland weston x11 native</tags>
@@ -29,5 +30,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />
     <file src="package/wslg_desktop.rdp" target="build/native/bin/wslg_desktop.rdp" />
+
+    <file src="package/NOTICE.txt" target="NOTICE.txt" />
+    <file src="LICENSE" target="LICENSE.txt" />
   </files>
 </package>

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -32,13 +32,23 @@
         },        
         {
             "Component": { 
-                "Type": "mesa", 
+                "Type": "git", 
                 "Git": {
-                    "RepositoryUrl": "https://github.com/mesa3d/mesa", 
-                    "CommitHash": "731ea06758663a2de3a2bd1f12eb8809d4c136fd"
+                    "RepositoryUrl": "https://gitlab.freedesktop.org/mesa/mesa", 
+                    "CommitHash": "be4f7fb656180ab55a50eff01f36672b0bf5f146"
                 }
             },
             "DevelopmentDependency": false
         },
+        {
+            "Component": { 
+                "Type": "git", 
+                "Git": {
+                    "RepositoryUrl": "https://github.com/microsoft/DirectX-Headers", 
+                    "CommitHash": "cf123266ce6f1e9a6e700642edb6356bff1e3d55"
+                }
+            },
+            "DevelopmentDependency": false
+        }
     ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -29,7 +29,7 @@
                 }
             },
             "DevelopmentDependency": false
-        },        
+        },
         {
             "Component": { 
                 "Type": "git", 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -34,7 +34,7 @@
             "Component": { 
                 "Type": "git", 
                 "Git": {
-                    "RepositoryUrl": "https://gitlab.freedesktop.org/mesa/mesa", 
+                    "RepositoryUrl": "https://gitlab.freedesktop.org/mesa/mesa.git", 
                     "CommitHash": "be4f7fb656180ab55a50eff01f36672b0bf5f146"
                 }
             },
@@ -44,7 +44,7 @@
             "Component": { 
                 "Type": "git", 
                 "Git": {
-                    "RepositoryUrl": "https://github.com/microsoft/DirectX-Headers", 
+                    "RepositoryUrl": "https://github.com/microsoft/DirectX-Headers.git", 
                     "CommitHash": "cf123266ce6f1e9a6e700642edb6356bff1e3d55"
                 }
             },


### PR DESCRIPTION
This PR addresses OSS compliance gaps in the WSLg NuGet package identified during a compliance audit.
cgmanifest.json changes:

 - Fix Mesa entry: change Type from "mesa" to "git" (was causing ComponentType Other (value Unknown) is not mapped parse errors in the SBOM task), update RepositoryUrl to the canonical GitLab source(gitlab.freedesktop.org/mesa/mesa), and update CommitHash to the correct mesa-23.1.0 tag commit (be4f7fb6...)
 - Add DirectX-Headers v1.608.0 entry (github.com/microsoft/DirectX-Headers, commit cf123266...)

Microsoft.WSLg.nuspec changes:

 - Add <license type="expression">MIT</license> metadata
 - Include NOTICE.txt (build-generated by notice@0 task) and LICENSE in the NuGet package payload
 
  PR Checklist

   -   Verified Mesa version (23.1.0) and DirectX-Headers version (v1.608.0) against pipeline defaults in devops/pipeline-shared.yml
   -   Verified Mesa commit hash against mesa-23.1.0 tag on gitlab.freedesktop.org
   -   Verified DirectX-Headers commit hash against v1.608.0 tag on GitHub
   
  Related
Companion PR in \wslg-build: [PR #15287628](https://microsoft.visualstudio.com/DxgkLinux/_git/wslg-build/pullrequest/15287628) : adds CG detection, SBOM generation, NOTICE.txt generation and verification to the build pipeline.

