### PR TITLE
Fix nuspec license type to unblock NuGet pack

### DIFF
--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -12,7 +12,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <projectUrl>https://github.com/microsoft/wslg</projectUrl>
     <repository type="git" url="https://github.com/microsoft/wslg.git" commit="$commit$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="file">LICENSE.txt</license>
+    <license type="expression">MIT</license>
     <description>WSLg system distribution and WSLDVCPlugin for the Windows Subsystem for Linux: Wayland, X11, audio (PulseAudio), and RemoteApp (RDP) support.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags>wsl wslg wayland weston x11 native</tags>


### PR DESCRIPTION
PR #1462 changed the nuspec license from `type="expression"` to `type="file"` 
 referencing LICENSE.txt. This causes `nuget pack` to fail with:

     Error NU5030: The license file 'LICENSE.txt' does not exist in the package.

 NuGet validates the license file reference before processing the <files> section,
 so even though LICENSE.txt is declared as a package file, the validation fails first.

 This reverts to `<license type="expression">MIT</license>` while keeping the
 LICENSE.txt file entry in <files> so the license text still ships in the package.