### PR TITLE
Include cgmanifest.json in NuGet package for WSL CG propagation

### DIFF
--- a/Microsoft.WSLg.nuspec
+++ b/Microsoft.WSLg.nuspec
@@ -31,6 +31,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <file src="package/wslg.rdp" target="build/native/bin/wslg.rdp" />
     <file src="package/wslg_desktop.rdp" target="build/native/bin/wslg_desktop.rdp" />
 
+    <file src="cgmanifest.json" target="cgmanifest.json" />
     <file src="package/NOTICE.txt" target="NOTICE.txt" />
     <file src="LICENSE" target="LICENSE.txt" />
   </files>


### PR DESCRIPTION
When WSL consumes the Microsoft.WSLg NuGet, Component Governance on the WSL pipeline only sees the NuGet package itself, it doesn't see the individual OSS components registered in WSLg's cgmanifest.json(PulseAudio, Weston, FreeRDP, Mesa, DirectX-Headers).

This adds cgmanifest.json to the NuGet package so that when WSL restores it to packages/Microsoft.WSLg.<version>/, CG's recursive scan picks up the registrations and they appear in the WSL compliance view.

Changes:  - Added <file src="cgmanifest.json" target="cgmanifest.json" /> to Microsoft.WSLg.nuspec