### PR TITLE
Fix Mesa cgmanifest URL for ClearlyDefined/NOTICE generation

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -34,7 +34,7 @@
             "Component": { 
                 "Type": "git", 
                 "Git": {
-                    "RepositoryUrl": "https://gitlab.freedesktop.org/mesa/mesa.git", 
+                    "RepositoryUrl": "https://gitlab.com/mesa/mesa", 
                     "CommitHash": "be4f7fb656180ab55a50eff01f36672b0bf5f146"
                 }
             },


### PR DESCRIPTION
 Mesa is missing from the generated NOTICE because the cgmanifest URL points to gitlab.freedesktop.org which the notice tool can't resolve. Updating to gitlab.com/mesa/mesa, same repo, just the URL the tool actually indexes.