### PR TITLE
Fix TranslateWindowsPath when USERPROFILE is a disk root

### DIFF
--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -106,6 +106,7 @@ std::string TranslateWindowsPath(const char * Path)
         result += buffer.data();
     }
     while (!result.empty() && (result.back() == '\n' || result.back() == '/')) {
+        result.pop_back();
     }
 
     THROW_ERRNO_IF(EINVAL, pclose(pipe.release()) != 0);

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -96,7 +96,7 @@ std::string TranslateWindowsPath(const char * Path)
 {
     std::string commandLine = "/usr/bin/wslpath -a \"";
     commandLine += Path;
-    commandLine += "\"";
+    commandLine += "\\\"";
     std::array<char, 128> buffer;
     std::string result;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(commandLine.c_str(), "r"), pclose);
@@ -105,8 +105,8 @@ std::string TranslateWindowsPath(const char * Path)
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         result += buffer.data();
     }
-    /* trim '\n' from wslpath output */
-    while (result.back() == '\n') {
+    /* trim '\n' and '/' from wslpath output */
+    while (result.back() == '\n' || result.back() == '/') {
         result.pop_back();
     }
 

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -105,9 +105,7 @@ std::string TranslateWindowsPath(const char * Path)
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         result += buffer.data();
     }
-    /* trim '\n' and '/' from wslpath output */
-    while (result.back() == '\n' || result.back() == '/') {
-        result.pop_back();
+    while (!result.empty() && (result.back() == '\n' || result.back() == '/')) {
     }
 
     THROW_ERRNO_IF(EINVAL, pclose(pipe.release()) != 0);

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -105,6 +105,7 @@ std::string TranslateWindowsPath(const char * Path)
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         result += buffer.data();
     }
+    /* trim '\n' and '/' from wslpath output */
     while (!result.empty() && (result.back() == '\n' || result.back() == '/')) {
         result.pop_back();
     }

--- a/WSLGd/main.cpp
+++ b/WSLGd/main.cpp
@@ -96,7 +96,7 @@ std::string TranslateWindowsPath(const char * Path)
 {
     std::string commandLine = "/usr/bin/wslpath -a \"";
     commandLine += Path;
-    commandLine += "\\\"";
+    commandLine += "/\"";
     std::array<char, 128> buffer;
     std::string result;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(commandLine.c_str(), "r"), pclose);


### PR DESCRIPTION
Closes https://github.com/microsoft/wslg/issues/1475

My attempt at fixing it, ~~untested~~ now tested.

Works by adding a slash to the Windows path being converted to WSL's one (i.e. `D:` gets converted to `D:/`, and even if there already is a slash in the end (would break in any case later) it still works fine) and removing it after the conversion.

Copilot has also requested me to add a check that `result` is not empty.